### PR TITLE
Add support for simple aggregations

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -13,7 +13,7 @@ import { nothing } from 'lit-html';
 import { Metadata } from '../src/models/metadata';
 import { MetadataResponse } from '../src/responses/metadata/metadata-response';
 import { SearchResponse } from '../src/responses/search/search-response';
-import { SearchParams } from '../src/search-params';
+import { AggregateSearchParams, SearchParams } from '../src/search-params';
 import { SearchService } from '../src/search-service';
 import { SearchServiceInterface } from '../src/search-service-interface';
 
@@ -116,10 +116,19 @@ export class AppRoot extends LitElement {
   async search(e: Event): Promise<void> {
     e.preventDefault();
     const term = this.searchInput.value;
+    const aggregations = new AggregateSearchParams({
+      advancedParams: [
+        {
+          field: 'year',
+          size: 100,
+        },
+      ],
+    });
     const searchParams = new SearchParams({
       query: term,
       rows: 10,
       fields: ['identifier', 'title'],
+      aggregations,
     });
     const result = await this.searchService.search(searchParams);
     if (result?.success) {

--- a/index.ts
+++ b/index.ts
@@ -33,4 +33,10 @@ export { SearchResponseParams } from './src/responses/search/search-response-par
 export { DefaultSearchBackend } from './src/search-backend/default-search-backend';
 export { SearchServiceInterface } from './src/search-service-interface';
 export { SearchService } from './src/search-service';
-export { SearchParams, SortParam, SortDirection, AggregateSearchParams, AggregateSearchParam } from './src/search-params';
+export {
+  SearchParams,
+  SortParam,
+  SortDirection,
+  AggregateSearchParams,
+  AggregateSearchParam,
+} from './src/search-params';

--- a/index.ts
+++ b/index.ts
@@ -33,5 +33,4 @@ export { SearchResponseParams } from './src/responses/search/search-response-par
 export { DefaultSearchBackend } from './src/search-backend/default-search-backend';
 export { SearchServiceInterface } from './src/search-service-interface';
 export { SearchService } from './src/search-service';
-export { SearchParams } from './src/search-params';
-export { SortParam } from './src/search-params';
+export { SearchParams, SortParam, SortDirection, AggregateSearchParams, AggregateSearchParam } from './src/search-params';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.2.6",
+  "version": "0.3.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.2.6",
+      "version": "0.3.0-alpha.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.3.0-alpha.3",
+      "version": "0.3.0-alpha.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.4",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.3.0-alpha.4",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.3.0-alpha.2",
+      "version": "0.3.0-alpha.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.2.6",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.2.6",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.4",
+  "version": "0.2.6",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.2.6",
+  "version": "0.2.5",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.2.6",
+  "version": "0.3.0-alpha.1",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/src/models/aggregation.ts
+++ b/src/models/aggregation.ts
@@ -19,4 +19,8 @@ export interface Aggregation {
   doc_count_error_upper_bound?: number;
   sum_other_doc_count?: number;
   buckets: Bucket[];
+  first_bucket_key?: number;
+  last_bucket_key?: number;
+  number_buckets?: number;
+  interval?: number;
 }

--- a/src/models/aggregation.ts
+++ b/src/models/aggregation.ts
@@ -18,7 +18,11 @@ export interface Bucket {
 export interface Aggregation {
   doc_count_error_upper_bound?: number;
   sum_other_doc_count?: number;
-  buckets: Bucket[];
+  /**
+   * The year_histogram returns a `number` array, and
+   * other facets return a `Bucket` array
+   */
+  buckets: Bucket[] | number[];
   first_bucket_key?: number;
   last_bucket_key?: number;
   number_buckets?: number;

--- a/test/search-params.test.ts
+++ b/test/search-params.test.ts
@@ -83,18 +83,62 @@ describe('SearchParams', () => {
     expect(queryAsString).to.equal(expected);
   });
 
-  it('properly generates a URLSearchParam with aggregations', async () => {
+  it('properly generates a URLSearchParam with advanced aggregations', async () => {
     const query = 'title:foo AND collection:bar';
-    const aggregations = new AggregateSearchParams([
-      {
-        field: 'foo',
-        size: 10,
-      },
-      {
-        field: 'bar',
-        size: 7,
-      },
-    ]);
+    const aggregations = new AggregateSearchParams({
+      advancedParams: [
+        {
+          field: 'foo',
+          size: 10,
+        },
+        {
+          field: 'bar',
+          size: 7,
+        },
+      ],
+    });
+    const params = new SearchParams({
+      query,
+      aggregations,
+    });
+    const urlSearchParam = params.asUrlSearchParams;
+    const queryAsString = urlSearchParam.toString();
+    const expected =
+      'q=title%3Afoo+AND+collection%3Abar&output=json&user_aggs=%5B%7B%22terms%22%3A%7B%22field%22%3A%22foo%22%2C%22size%22%3A10%7D%7D%2C%7B%22terms%22%3A%7B%22field%22%3A%22bar%22%2C%22size%22%3A7%7D%7D%5D';
+    expect(queryAsString).to.equal(expected);
+  });
+
+  it('properly generates a URLSearchParam with simple aggregations', async () => {
+    const query = 'title:foo AND collection:bar';
+    const aggregations = new AggregateSearchParams({
+      simpleParams: ['year', 'collection', 'subject'],
+    });
+    const params = new SearchParams({
+      query,
+      aggregations,
+    });
+    const urlSearchParam = params.asUrlSearchParams;
+    const queryAsString = urlSearchParam.toString();
+    const expected =
+      'q=title%3Afoo+AND+collection%3Abar&output=json&user_aggs=year%2Ccollection%2Csubject';
+    expect(queryAsString).to.equal(expected);
+  });
+
+  it('advanced aggregations take precedence if both simple and advanced provided', async () => {
+    const query = 'title:foo AND collection:bar';
+    const aggregations = new AggregateSearchParams({
+      advancedParams: [
+        {
+          field: 'foo',
+          size: 10,
+        },
+        {
+          field: 'bar',
+          size: 7,
+        },
+      ],
+      simpleParams: ['year'],
+    });
     const params = new SearchParams({
       query,
       aggregations,


### PR DESCRIPTION
There are certain fields in the aggregations (facets), particularly the year histogram facet where the data is different depending on how it is requested: "simple" facets vs json-style "advanced" facets. This adds support for both formats so we can request the year histogram independently from the other facets.