### PR TITLE
file.external_identifer can be an array of strings

### DIFF
--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -87,7 +87,7 @@ export class File {
       : undefined;
   }
 
-  get external_identifier(): string | undefined {
+  get external_identifier(): string | string[] | undefined {
     return this.rawValue.external_identifier;
   }
 


### PR DESCRIPTION
ex. https://archive.org/metadata/cd_taylor-swift_taylor-swift 
has file info with a list of external_identifiers
```
{
"name": "disc1/01. Taylor Swift - Tim McGraw.flac",
"source": "original",
"mtime": "1515314129",
"size": "28581095",
"md5": "748e4988def50a1d271007d9855665fa",
"crc32": "4873b495",
"sha1": "f65a750cf86b87f43d4117e87f8b0271744b3036",
"format": "Flac",
"length": "234.55",
"height": "640",
"width": "640",
"private": "true",
"album": "Taylor Swift",
"comment": "https://archive.org/details/cd_taylor-swift_taylor-swift",
"title": "Tim McGraw",
"artist": "Taylor Swift",
"track": "1",
"external-identifier": [
"urn:acoustid:c1b6f24a-d9c3-400f-80d1-2c13d9a47bfd",
"urn:mb_recording_id:4bea9dc0-11d3-4dc1-936b-73361da356eb",
"urn:spotify:track:0Om9WAB5RS09L80DyOfTNa",
"urn:youtube:GkD20ajVxnY"
],
"external-identifier-match-date": [
"acoustid:2018-12-17T12:25:12Z",
"mb_recording_id:2018-09-13T11:48:54Z",
"spotify:2018-08-22T17:20:06Z",
"youtube:2018-07-02T03:51:23Z"
]
},
```
