### PR TITLE
Add snippets field to metadata model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -349,6 +349,12 @@ export class Metadata {
       : undefined;
   }
 
+  @Memoize() get snippets(): StringField | undefined {
+    return this.rawMetadata?.snippets
+      ? new StringField(this.rawMetadata.snippets)
+      : undefined;
+  }
+
   @Memoize() get source(): StringField | undefined {
     return this.rawMetadata?.source
       ? new StringField(this.rawMetadata.source)


### PR DESCRIPTION
Just adding a getter for text snippets on the Metadata model, to prepare for FTS integration.

Bumps version to 0.3.5