### PR TITLE
WEBDEV-5516 Add new fields being returned by PPS

### DIFF
--- a/src/models/hit-types/item-hit.ts
+++ b/src/models/hit-types/item-hit.ts
@@ -2,6 +2,7 @@
 import { Memoize } from 'typescript-memoize';
 import type { Metadata } from '../metadata';
 import { BooleanField } from '../metadata-fields/field-types/boolean';
+import { ByteField } from '../metadata-fields/field-types/byte';
 import { DateField } from '../metadata-fields/field-types/date';
 import { MediaTypeField } from '../metadata-fields/field-types/mediatype';
 import { NumberField } from '../metadata-fields/field-types/number';
@@ -47,7 +48,7 @@ export class ItemHit {
 
   /** Optional. */
   @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
-    return this.rawMetadata?.fields?.avg_rating
+    return this.rawMetadata?.fields?.avg_rating != null
       ? new NumberField(this.rawMetadata.fields.avg_rating)
       : undefined;
   }
@@ -67,7 +68,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get collection_files_count(): NumberField | undefined {
-    return this.rawMetadata?.fields?.collection_files_count
+    return this.rawMetadata?.fields?.collection_files_count != null
       ? new NumberField(this.rawMetadata.fields.collection_files_count)
       : undefined;
   }
@@ -77,8 +78,8 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get collection_size(): typeof Metadata.prototype.collection_size {
-    return this.rawMetadata?.fields?.collection_size
-      ? new NumberField(this.rawMetadata.fields.collection_size)
+    return this.rawMetadata?.fields?.collection_size != null
+      ? new ByteField(this.rawMetadata.fields.collection_size)
       : undefined;
   }
 
@@ -113,7 +114,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get downloads(): typeof Metadata.prototype.downloads {
-    return this.rawMetadata?.fields?.downloads
+    return this.rawMetadata?.fields?.downloads != null
       ? new NumberField(this.rawMetadata.fields.downloads)
       : undefined;
   }
@@ -122,7 +123,7 @@ export class ItemHit {
    * Computed during document construction.
    */
   @Memoize() get files_count(): typeof Metadata.prototype.files_count {
-    return this.rawMetadata?.fields?.files_count
+    return this.rawMetadata?.fields?.files_count != null
       ? new NumberField(this.rawMetadata.fields.files_count)
       : undefined;
   }
@@ -162,7 +163,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get item_count(): typeof Metadata.prototype.item_count {
-    return this.rawMetadata?.fields?.item_count
+    return this.rawMetadata?.fields?.item_count != null
       ? new NumberField(this.rawMetadata.fields.item_count)
       : undefined;
   }
@@ -171,8 +172,8 @@ export class ItemHit {
    * In bytes; computed during document construction.
    */
   @Memoize() get item_size(): typeof Metadata.prototype.item_size {
-    return this.rawMetadata?.fields?.item_size
-      ? new NumberField(this.rawMetadata.fields.item_size)
+    return this.rawMetadata?.fields?.item_size != null
+      ? new ByteField(this.rawMetadata.fields.item_size)
       : undefined;
   }
 
@@ -246,7 +247,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get month(): typeof Metadata.prototype.month {
-    return this.rawMetadata?.fields?.month
+    return this.rawMetadata?.fields?.month != null
       ? new NumberField(this.rawMetadata.fields.month)
       : undefined;
   }
@@ -263,7 +264,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get num_favorites(): typeof Metadata.prototype.num_favorites {
-    return this.rawMetadata?.fields?.num_favorites
+    return this.rawMetadata?.fields?.num_favorites != null
       ? new NumberField(this.rawMetadata.fields.num_favorites)
       : undefined;
   }
@@ -273,7 +274,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get num_reviews(): typeof Metadata.prototype.num_reviews {
-    return this.rawMetadata?.fields?.num_reviews
+    return this.rawMetadata?.fields?.num_reviews != null
       ? new NumberField(this.rawMetadata.fields.num_reviews)
       : undefined;
   }
@@ -324,7 +325,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get week(): typeof Metadata.prototype.week {
-    return this.rawMetadata?.fields?.week
+    return this.rawMetadata?.fields?.week != null
       ? new NumberField(this.rawMetadata.fields.week)
       : undefined;
   }
@@ -334,7 +335,7 @@ export class ItemHit {
    * Optional.
    */
   @Memoize() get year(): NumberField | undefined {
-    return this.rawMetadata?.fields?.year
+    return this.rawMetadata?.fields?.year != null
       ? new NumberField(this.rawMetadata.fields.year)
       : undefined;
   }

--- a/src/models/hit-types/item-hit.ts
+++ b/src/models/hit-types/item-hit.ts
@@ -38,6 +38,20 @@ export class ItemHit {
     return this.rawMetadata?.fields?.identifier;
   }
 
+  /** Optional. */
+  @Memoize() get addeddate(): typeof Metadata.prototype.addeddate {
+    return this.rawMetadata?.fields?.addeddate
+      ? new DateField(this.rawMetadata.fields.addeddate)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
+    return this.rawMetadata?.fields?.avg_rating
+      ? new NumberField(this.rawMetadata.fields.avg_rating)
+      : undefined;
+  }
+
   /**
    * May be a superset of metadata collection field.
    * Multivalued.
@@ -130,6 +144,26 @@ export class ItemHit {
   @Memoize() get indexflag(): StringField | undefined {
     return this.rawMetadata?.fields?.indexflag
       ? new StringField(this.rawMetadata.fields.indexflag)
+      : undefined;
+  }
+
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get issue(): typeof Metadata.prototype.issue {
+    return this.rawMetadata?.fields?.issue
+      ? new StringField(this.rawMetadata.fields.issue)
+      : undefined;
+  }
+
+  /**
+   * Computed during document construction.
+   * Optional.
+   */
+  @Memoize() get item_count(): typeof Metadata.prototype.item_count {
+    return this.rawMetadata?.fields?.item_count
+      ? new NumberField(this.rawMetadata.fields.item_count)
       : undefined;
   }
 
@@ -241,6 +275,16 @@ export class ItemHit {
   @Memoize() get num_reviews(): typeof Metadata.prototype.num_reviews {
     return this.rawMetadata?.fields?.num_reviews
       ? new NumberField(this.rawMetadata.fields.num_reviews)
+      : undefined;
+  }
+
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get source(): typeof Metadata.prototype.source {
+    return this.rawMetadata?.fields?.source
+      ? new StringField(this.rawMetadata.fields.source)
       : undefined;
   }
 

--- a/src/models/hit-types/text-hit.ts
+++ b/src/models/hit-types/text-hit.ts
@@ -61,7 +61,7 @@ export class TextHit {
 
   /** Optional. */
   @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
-    return this.rawMetadata?.fields?.avg_rating
+    return this.rawMetadata?.fields?.avg_rating != null
       ? new NumberField(this.rawMetadata.fields.avg_rating)
       : undefined;
   }
@@ -112,7 +112,7 @@ export class TextHit {
    * Optional.
    */
   @Memoize() get downloads(): typeof Metadata.prototype.downloads {
-    return this.rawMetadata?.fields?.downloads
+    return this.rawMetadata?.fields?.downloads != null
       ? new NumberField(this.rawMetadata.fields.downloads)
       : undefined;
   }
@@ -130,7 +130,7 @@ export class TextHit {
   }
 
   @Memoize() get file_creation_mtime(): NumberField | undefined {
-    return this.rawMetadata?.fields?.file_creation_mtime
+    return this.rawMetadata?.fields?.file_creation_mtime != null
       ? new NumberField(this.rawMetadata.fields.file_creation_mtime)
       : undefined;
   }
@@ -153,7 +153,7 @@ export class TextHit {
 
   /** Optional. */
   @Memoize() get page_num(): NumberField | undefined {
-    return this.rawMetadata?.fields?.page_num
+    return this.rawMetadata?.fields?.page_num != null
       ? new NumberField(this.rawMetadata.fields.page_num)
       : undefined;
   }
@@ -219,7 +219,7 @@ export class TextHit {
    * Optional.
    */
   @Memoize() get year(): NumberField | undefined {
-    return this.rawMetadata?.fields?.year
+    return this.rawMetadata?.fields?.year != null
       ? new NumberField(this.rawMetadata.fields.year)
       : undefined;
   }

--- a/src/models/hit-types/text-hit.ts
+++ b/src/models/hit-types/text-hit.ts
@@ -49,6 +49,23 @@ export class TextHit {
       : undefined;
   }
 
+  /**
+   * May be stale in FTS.
+   * Optional.
+   */
+  @Memoize() get addeddate(): typeof Metadata.prototype.addeddate {
+    return this.rawMetadata?.fields?.addeddate
+      ? new DateField(this.rawMetadata.fields.addeddate)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
+    return this.rawMetadata?.fields?.avg_rating
+      ? new NumberField(this.rawMetadata.fields.avg_rating)
+      : undefined;
+  }
+
   /** Multivalued. */
   @Memoize() get collection(): typeof Metadata.prototype.collection {
     return this.rawMetadata?.fields?.collection
@@ -118,6 +135,16 @@ export class TextHit {
       : undefined;
   }
 
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get issue(): typeof Metadata.prototype.issue {
+    return this.rawMetadata?.fields?.issue
+      ? new StringField(this.rawMetadata.fields.issue)
+      : undefined;
+  }
+
   @Memoize() get mediatype(): typeof Metadata.prototype.mediatype {
     return this.rawMetadata?.fields?.mediatype
       ? new MediaTypeField(this.rawMetadata.fields.mediatype)
@@ -151,6 +178,16 @@ export class TextHit {
   @Memoize() get reviewdate(): typeof Metadata.prototype.reviewdate {
     return this.rawMetadata?.fields?.reviewdate
       ? new DateField(this.rawMetadata.fields.reviewdate)
+      : undefined;
+  }
+
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get source(): typeof Metadata.prototype.source {
+    return this.rawMetadata?.fields?.source
+      ? new StringField(this.rawMetadata.fields.source)
       : undefined;
   }
 

--- a/test/models/hit-types/item-hit.test.ts
+++ b/test/models/hit-types/item-hit.test.ts
@@ -71,8 +71,12 @@ describe('ItemHit', () => {
       }
     }
 
+    expect(hit.addeddate?.value).to.be.undefined;
+    expect(hit.avg_rating?.value).to.be.undefined;
     expect(hit.collection_files_count?.value).to.be.undefined;
     expect(hit.collection_size?.value).to.be.undefined;
+    expect(hit.issue?.value).to.be.undefined;
+    expect(hit.item_count?.value).to.be.undefined;
     expect(hit.genre?.value).to.be.undefined;
     expect(hit.language?.value).to.be.undefined;
     expect(hit.lending___status?.value).to.be.undefined;
@@ -80,6 +84,7 @@ describe('ItemHit', () => {
     expect(hit.noindex?.value).to.be.undefined;
     expect(hit.num_favorites?.value).to.be.undefined;
     expect(hit.num_reviews?.value).to.be.undefined;
+    expect(hit.source?.value).to.be.undefined;
     expect(hit.type?.value).to.be.undefined;
     expect(hit.volume?.value).to.be.undefined;
   });
@@ -106,14 +111,19 @@ describe('ItemHit', () => {
         lending___available_to_browse: false,
         lending___available_to_waitlist: false,
         lending___status: 'foo-status',
+        addeddate: '2011-07-20T00:00:00Z',
+        avg_rating: 3,
         collection_files_count: 124,
         collection_size: 125,
         genre: 'foo-genre',
+        issue: 'foo-issue',
+        item_count: 0,
         language: 'foo-language',
         licenseurl: 'foo-license',
         noindex: true,
         num_favorites: 126,
         num_reviews: 127,
+        source: 'foo-source',
         type: 'foo-type',
         volume: 'foo-volume',
       },
@@ -131,13 +141,20 @@ describe('ItemHit', () => {
       const fieldName = key as Exclude<keyof typeof json.fields, 'identifier'>;
 
       if (Array.isArray(json.fields[fieldName])) {
-        expect(hit[fieldName]?.values).to.deep.equal(json.fields[fieldName]);
+        expect(hit[fieldName]?.values).to.deep.equal(
+          json.fields[fieldName],
+          fieldName
+        );
       } else if (hit[fieldName] instanceof DateField) {
         expect(hit[fieldName]?.value).to.deep.equal(
-          DateParser.shared.parseValue(json.fields[fieldName].toString())
+          DateParser.shared.parseValue(json.fields[fieldName].toString()),
+          fieldName
         );
       } else {
-        expect(hit[fieldName]?.value).to.equal(json.fields[fieldName]);
+        expect(hit[fieldName]?.value).to.equal(
+          json.fields[fieldName],
+          fieldName
+        );
       }
     }
   });

--- a/test/models/hit-types/item-hit.test.ts
+++ b/test/models/hit-types/item-hit.test.ts
@@ -3,6 +3,43 @@ import { expect } from '@open-wc/testing';
 import { ItemHit } from '../../../src/models/hit-types/item-hit';
 import { DateField } from '../../../src/models/metadata-fields/field-types/date';
 
+const fieldNames: (keyof ItemHit)[] = [
+  'identifier',
+  'addeddate',
+  'avg_rating',
+  'collection',
+  'collection_files_count',
+  'collection_size',
+  'creator',
+  'date',
+  'description',
+  'downloads',
+  'files_count',
+  'genre',
+  'indexflag',
+  'issue',
+  'item_count',
+  'item_size',
+  'lending___available_to_borrow',
+  'lending___available_to_browse',
+  'lending___available_to_waitlist',
+  'lending___status',
+  'language',
+  'licenseurl',
+  'mediatype',
+  'month',
+  'noindex',
+  'num_favorites',
+  'num_reviews',
+  'source',
+  'subject',
+  'title',
+  'type',
+  'volume',
+  'week',
+  'year',
+];
+
 describe('ItemHit', () => {
   it('constructs basic item hit', () => {
     const hit = new ItemHit({ fields: {} });
@@ -16,13 +53,18 @@ describe('ItemHit', () => {
     expect(hit.title).to.be.undefined;
   });
 
-  it('handles incomplete data without throwing', () => {
+  it('handles missing data gracefully', () => {
     const hit = new ItemHit({});
-    expect(hit.creator).to.be.undefined;
-    expect(hit.date).to.be.undefined;
-    expect(hit.description).to.be.undefined;
-    expect(hit.subject).to.be.undefined;
-    expect(hit.title).to.be.undefined;
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
+  });
+
+  it('handles incomplete field data gracefully', () => {
+    const hit = new ItemHit({ fields: {} });
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
   });
 
   it('constructs item hit with partial fields', () => {
@@ -105,7 +147,7 @@ describe('ItemHit', () => {
         files_count: 5,
         downloads: 123,
         week: 2,
-        month: 15,
+        month: 11,
         indexflag: ['index', 'nonoindex'],
         lending___available_to_borrow: false,
         lending___available_to_browse: false,
@@ -157,5 +199,49 @@ describe('ItemHit', () => {
         );
       }
     }
+  });
+
+  it('correctly parses falsey boolean/numeric fields', () => {
+    const json = {
+      fields: {
+        identifier: 'foo',
+        lending___available_to_borrow: false,
+        lending___available_to_browse: false,
+        lending___available_to_waitlist: false,
+        noindex: false,
+        item_size: 0,
+        files_count: 0,
+        downloads: 0,
+        week: 0,
+        month: 0,
+        year: 0,
+        avg_rating: 0,
+        collection_files_count: 0,
+        collection_size: 0,
+        item_count: 0,
+        num_favorites: 0,
+        num_reviews: 0,
+      },
+      highlight: null,
+      _score: 0,
+    };
+
+    const hit = new ItemHit(json);
+    expect(hit.lending___available_to_borrow?.value).to.be.false;
+    expect(hit.lending___available_to_browse?.value).to.be.false;
+    expect(hit.lending___available_to_waitlist?.value).to.be.false;
+    expect(hit.noindex?.value).to.be.false;
+    expect(hit.item_size?.value).to.equal(0);
+    expect(hit.files_count?.value).to.equal(0);
+    expect(hit.downloads?.value).to.equal(0);
+    expect(hit.week?.value).to.equal(0);
+    expect(hit.month?.value).to.equal(0);
+    expect(hit.year?.value).to.equal(0);
+    expect(hit.avg_rating?.value).to.equal(0);
+    expect(hit.collection_files_count?.value).to.equal(0);
+    expect(hit.collection_size?.value).to.equal(0);
+    expect(hit.item_count?.value).to.equal(0);
+    expect(hit.num_favorites?.value).to.equal(0);
+    expect(hit.num_reviews?.value).to.equal(0);
   });
 });

--- a/test/models/hit-types/text-hit.test.ts
+++ b/test/models/hit-types/text-hit.test.ts
@@ -3,6 +3,34 @@ import { expect } from '@open-wc/testing';
 import { TextHit } from '../../../src/models/hit-types/text-hit';
 import { DateField } from '../../../src/models/metadata-fields/field-types/date';
 
+const fieldNames: (keyof TextHit)[] = [
+  'identifier',
+  'addeddate',
+  'avg_rating',
+  'collection',
+  'created_on',
+  'creator',
+  'date',
+  'description',
+  'downloads',
+  'filename',
+  'file_basename',
+  'file_creation_mtime',
+  'highlight',
+  'issue',
+  'mediatype',
+  'page_num',
+  'publicdate',
+  'result_in_subfile',
+  'reviewdate',
+  'source',
+  'subject',
+  'title',
+  'updated_on',
+  'year',
+  '__href__',
+];
+
 describe('TextHit', () => {
   it('constructs basic text hit', () => {
     const hit = new TextHit({ fields: {} });
@@ -10,13 +38,18 @@ describe('TextHit', () => {
     expect(hit.creator).to.be.undefined;
   });
 
-  it('handles incomplete data without throwing', () => {
+  it('handles missing data gracefully', () => {
     const hit = new TextHit({});
-    expect(hit.creator).to.be.undefined;
-    expect(hit.date).to.be.undefined;
-    expect(hit.description).to.be.undefined;
-    expect(hit.subject).to.be.undefined;
-    expect(hit.title).to.be.undefined;
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
+  });
+
+  it('handles incomplete field data gracefully', () => {
+    const hit = new TextHit({ fields: {} });
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
   });
 
   it('constructs text hit with all fields', () => {
@@ -38,6 +71,7 @@ describe('TextHit', () => {
         issue: 'foo-issue',
         source: 'foo-source',
         date: '1904-01-01T00:00:00Z',
+        reviewdate: '1904-01-01T00:00:00Z',
         publicdate: '2006-10-11T08:19:20Z',
         downloads: 1234,
         collection: ['foo-collection'],
@@ -80,5 +114,31 @@ describe('TextHit', () => {
     }
 
     expect(hit.highlight?.values).to.deep.equal(json.highlight.text);
+  });
+
+  it('correctly parses falsey boolean/numeric fields', () => {
+    const json = {
+      fields: {
+        identifier: 'foo',
+        result_in_subfile: false,
+        file_creation_mtime: 0,
+        page_num: 0,
+        avg_rating: 0,
+        downloads: 0,
+        year: 0,
+      },
+      highlight: {
+        text: [],
+      },
+      _score: 0,
+    };
+
+    const hit = new TextHit(json);
+    expect(hit.result_in_subfile?.value).to.be.false;
+    expect(hit.file_creation_mtime?.value).to.equal(0);
+    expect(hit.page_num?.value).to.equal(0);
+    expect(hit.avg_rating?.value).to.equal(0);
+    expect(hit.downloads?.value).to.equal(0);
+    expect(hit.year?.value).to.equal(0);
   });
 });

--- a/test/models/hit-types/text-hit.test.ts
+++ b/test/models/hit-types/text-hit.test.ts
@@ -33,6 +33,10 @@ describe('TextHit', () => {
         title: 'foo-title',
         creator: ['foo-creator'],
         subject: ['foo-subject1', 'foo-subject2'],
+        addeddate: '1904-01-01T00:00:00Z',
+        avg_rating: 3,
+        issue: 'foo-issue',
+        source: 'foo-source',
         date: '1904-01-01T00:00:00Z',
         publicdate: '2006-10-11T08:19:20Z',
         downloads: 1234,
@@ -58,13 +62,20 @@ describe('TextHit', () => {
       const fieldName = key as Exclude<keyof typeof json.fields, 'identifier'>;
 
       if (Array.isArray(json.fields[fieldName])) {
-        expect(hit[fieldName]?.values).to.deep.equal(json.fields[fieldName]);
+        expect(hit[fieldName]?.values).to.deep.equal(
+          json.fields[fieldName],
+          fieldName
+        );
       } else if (hit[fieldName] instanceof DateField) {
         expect(hit[fieldName]?.value).to.deep.equal(
-          DateParser.shared.parseValue(json.fields[fieldName].toString())
+          DateParser.shared.parseValue(json.fields[fieldName].toString()),
+          fieldName
         );
       } else {
-        expect(hit[fieldName]?.value).to.equal(json.fields[fieldName]);
+        expect(hit[fieldName]?.value).to.equal(
+          json.fields[fieldName],
+          fieldName
+        );
       }
     }
 


### PR DESCRIPTION
The PPS hit schemas have been updated to include several fields that were previously missing: `addeddate`, `avg_rating`, `issue`, `item_count`, and `source`. This PR adds those to the search service hit types so that they are more readily available to consumers.