### PR TITLE
WEBDEV-5544 Add `uid` and `client_url` PPS params

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -8,6 +8,7 @@ import { SearchType } from '../src/search-type';
 import { SearchParams, SortDirection } from '../src/search-params';
 import { Aggregation, Bucket } from '../src/models/aggregation';
 import { SearchBackendOptionsInterface } from '../src/search-backend/search-backend-options';
+import { SearchParamURLGenerator } from '../src/search-param-url-generator';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -43,6 +44,12 @@ export class AppRoot extends LitElement {
 
   @state()
   private loadingAggregations = false;
+
+  @state()
+  private lastSearchParams?: string;
+
+  @state()
+  private lastAggregationParams?: string;
 
   @state()
   private defaultAggregationsChecked = true;
@@ -212,6 +219,18 @@ export class AppRoot extends LitElement {
 
   private get resultsTemplate(): TemplateResult {
     return html`
+      ${this.lastSearchParams
+        ? html`<div>
+            Last search params:
+            <pre>${this.lastSearchParams}</pre>
+          </div>`
+        : nothing}
+      ${this.lastAggregationParams
+        ? html`<div>
+            Last aggregation params:
+            <pre>${this.lastAggregationParams}</pre>
+          </div>`
+        : nothing}
       ${this.loadingSearchResults
         ? html`<h3>Loading search results...</h3>`
         : [this.minimalSearchResultsTemplate, this.fullSearchResultsTemplate]}
@@ -348,6 +367,7 @@ export class AppRoot extends LitElement {
       sort: sortParam,
       aggregations: { omit: true },
       debugging: includeDebugging,
+      uid: 'demo',
     };
 
     this.loadingSearchResults = true;
@@ -356,6 +376,9 @@ export class AppRoot extends LitElement {
 
     if (result?.success) {
       this.searchResponse = result?.success;
+      this.lastSearchParams = SearchParamURLGenerator.generateURLSearchParams(
+        searchParams
+      ).toString();
     } else {
       alert(`Oh noes: ${result?.error?.message}`);
       console.error('Error searching', result?.error);
@@ -383,6 +406,7 @@ export class AppRoot extends LitElement {
       rows: 0,
       aggregationsSize: numAggs,
       debugging: includeDebugging,
+      uid: 'demo',
     };
 
     if (!this.defaultAggregationsChecked) {
@@ -395,6 +419,9 @@ export class AppRoot extends LitElement {
 
     if (result?.success) {
       this.aggregationsResponse = result?.success;
+      this.lastAggregationParams = SearchParamURLGenerator.generateURLSearchParams(
+        searchParams
+      ).toString();
     } else {
       alert(`Oh noes: ${result?.error?.message}`);
       console.error('Error searching', result?.error);
@@ -409,6 +436,10 @@ export class AppRoot extends LitElement {
 
       .field-row {
         margin: 0.3rem 0;
+      }
+
+      fieldset {
+        margin-bottom: 0.5rem;
       }
     `;
   }

--- a/src/search-param-url-generator.ts
+++ b/src/search-param-url-generator.ts
@@ -101,6 +101,14 @@ export class SearchParamURLGenerator {
       params.append('debugging', 'true');
     }
 
+    if (searchParams.uid) {
+      params.append('uid', searchParams.uid);
+    }
+
+    if (searchParams.includeClientUrl !== false) {
+      params.append('client_url', window.location.href);
+    }
+
     return params;
   }
 }

--- a/src/search-params.ts
+++ b/src/search-params.ts
@@ -122,4 +122,17 @@ export interface SearchParams {
    * Whether to include debugging info in the returned PPS response.
    */
   debugging?: boolean;
+
+  /**
+   * A unique request ID to pass to the service.
+   * Will be returned unmodified in the response, for ease of tracking responses,
+   * e.g., to quickly determine whether a given response has obsolete data.
+   */
+  uid?: string;
+
+  /**
+   * Whether to include the client URL in the request (used for PPS debugging).
+   * Defaults to true.
+   */
+  includeClientUrl?: boolean;
 }

--- a/src/search-params.ts
+++ b/src/search-params.ts
@@ -135,7 +135,7 @@ export interface SearchParams {
    * This is useful for PPS debugging as it allows the backend folks to compare
    * any PPS response issues with the client URLs that generated them,
    * especially for issues related to parameter parsing & normalization.
-   * 
+   *
    * This defaults to true, as these should be sent on every request unless
    * there is a specific need not to include them for certain request types.
    */

--- a/src/search-params.ts
+++ b/src/search-params.ts
@@ -131,8 +131,13 @@ export interface SearchParams {
   uid?: string;
 
   /**
-   * Whether to include the client URL in the request (used for PPS debugging).
-   * Defaults to true.
+   * Whether to include the client URL in the request.
+   * This is useful for PPS debugging as it allows the backend folks to compare
+   * any PPS response issues with the client URLs that generated them,
+   * especially for issues related to parameter parsing & normalization.
+   * 
+   * This defaults to true, as these should be sent on every request unless
+   * there is a specific need not to include them for certain request types.
    */
   includeClientUrl?: boolean;
 }

--- a/src/search-params.ts
+++ b/src/search-params.ts
@@ -137,7 +137,10 @@ export interface SearchParams {
    * especially for issues related to parameter parsing & normalization.
    *
    * This defaults to true, as these should be sent on every request unless
-   * there is a specific need not to include them for certain request types.
+   * there is a specific need not to include them for certain request types. Thus:
+   *  * `includeClientUrl: undefined` causes `client_url` param to be included in the request, by default.
+   *  * `includeClientUrl: true` causes `client_url` param to be included, explicitly.
+   *  * `includeClientUrl: false` causes `client_url` param to _not_ be included in the request.
    */
   includeClientUrl?: boolean;
 }

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -81,11 +81,11 @@ describe('FulltextSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop', includeClientUrl: false });
+      await backend.performSearch({ query: 'boop' });
 
-      expect(urlCalled!.toString()).to.equal(
-        'https://foo.bar/baz/?service_backend=fts&user_query=boop&debugging=true'
-      );
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.equal('true');
     });
 
     it('can disable default debugging on individual searches', async () => {

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -81,7 +81,7 @@ describe('FulltextSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop' });
+      await backend.performSearch({ query: 'boop', includeClientUrl: false });
 
       expect(urlCalled!.toString()).to.equal(
         'https://foo.bar/baz/?service_backend=fts&user_query=boop&debugging=true'
@@ -94,7 +94,11 @@ describe('FulltextSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop', debugging: false });
+      await backend.performSearch({
+        query: 'boop',
+        debugging: false,
+        includeClientUrl: false,
+      });
 
       expect(urlCalled!.toString()).to.equal(
         'https://foo.bar/baz/?service_backend=fts&user_query=boop'

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -97,12 +97,11 @@ describe('FulltextSearchBackend', () => {
       await backend.performSearch({
         query: 'boop',
         debugging: false,
-        includeClientUrl: false,
       });
 
-      expect(urlCalled!.toString()).to.equal(
-        'https://foo.bar/baz/?service_backend=fts&user_query=boop'
-      );
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.be.null;
     });
   });
 

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -81,11 +81,11 @@ describe('MetadataSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop', includeClientUrl: false });
+      await backend.performSearch({ query: 'boop' });
 
-      expect(urlCalled!.toString()).to.equal(
-        'https://foo.bar/baz/?service_backend=metadata&user_query=boop&debugging=true'
-      );
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.equal('true');
     });
 
     it('can disable default debugging on individual searches', async () => {

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -81,7 +81,7 @@ describe('MetadataSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop' });
+      await backend.performSearch({ query: 'boop', includeClientUrl: false });
 
       expect(urlCalled!.toString()).to.equal(
         'https://foo.bar/baz/?service_backend=metadata&user_query=boop&debugging=true'
@@ -94,7 +94,11 @@ describe('MetadataSearchBackend', () => {
         servicePath: '/baz',
         debuggingEnabled: true,
       });
-      await backend.performSearch({ query: 'boop', debugging: false });
+      await backend.performSearch({
+        query: 'boop',
+        debugging: false,
+        includeClientUrl: false,
+      });
 
       expect(urlCalled!.toString()).to.equal(
         'https://foo.bar/baz/?service_backend=metadata&user_query=boop'

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -97,12 +97,11 @@ describe('MetadataSearchBackend', () => {
       await backend.performSearch({
         query: 'boop',
         debugging: false,
-        includeClientUrl: false,
       });
 
-      expect(urlCalled!.toString()).to.equal(
-        'https://foo.bar/baz/?service_backend=metadata&user_query=boop'
-      );
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.be.null;
     });
   });
 

--- a/test/search-params.test.ts
+++ b/test/search-params.test.ts
@@ -299,6 +299,43 @@ describe('SearchParams', () => {
 
     // Don't rely on exact web-test-runner URLs, just verify the param was added and is a valid URL
     expect(queryParams.get('client_url')).to.exist;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(new URL(queryParams.get('client_url')!)).not.to.throw;
+  });
+
+  it('does not include client url when includeClientURL=false', async () => {
+    const query = 'title:foo';
+    const params = {
+      query,
+      includeClientUrl: false,
+    };
+    const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
+      params
+    );
+    const queryAsString = urlSearchParam.toString();
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('client_url')).to.be.null;
+  });
+
+  it('does include client url when includeClientURL=true', async () => {
+    const query = 'title:foo';
+    const params = {
+      query,
+      includeClientUrl: true,
+    };
+    const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
+      params
+    );
+    const queryAsString = urlSearchParam.toString();
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+
+    // Don't rely on exact web-test-runner URLs, just verify the param was added and is a valid URL
+    expect(queryParams.get('client_url')).to.exist;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(new URL(queryParams.get('client_url')!)).not.to.throw;
   });
 });

--- a/test/search-params.test.ts
+++ b/test/search-params.test.ts
@@ -27,8 +27,9 @@ describe('SearchParams', () => {
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected = 'user_query=title%3Afoo+AND+collection%3Abar';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
   });
 
   it('properly generates a URLSearchParam with a query and fields', async () => {
@@ -37,18 +38,18 @@ describe('SearchParams', () => {
     const params = {
       query,
       fields,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&fields=identifier%2Cfoo%2Cbar';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('fields')).to.equal('identifier,foo,bar');
   });
 
-  it('properly generates a URLSearchParam with a query, sort, row, start, and fields', async () => {
+  it('properly generates a URLSearchParam with a query, sort, rows, page, and fields', async () => {
     const query = 'title:foo AND collection:bar';
     const fields = ['identifier', 'foo', 'bar'];
     const sort: SortParam[] = [{ field: 'downloads', direction: 'desc' }];
@@ -58,15 +59,18 @@ describe('SearchParams', () => {
       rows: 53,
       page: 27,
       fields,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&hits_per_page=53&page=27&fields=identifier%2Cfoo%2Cbar&sort=downloads%3Adesc';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('hits_per_page')).to.equal('53');
+    expect(queryParams.get('page')).to.equal('27');
+    expect(queryParams.get('fields')).to.equal('identifier,foo,bar');
+    expect(queryParams.get('sort')).to.equal('downloads:desc');
   });
 
   it('properly generates a URLSearchParam multiple sort params', async () => {
@@ -80,15 +84,17 @@ describe('SearchParams', () => {
       sort,
       rows: 53,
       page: 27,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&hits_per_page=53&page=27&sort=downloads%3Adesc%2Cfoo%3Aasc';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('hits_per_page')).to.equal('53');
+    expect(queryParams.get('page')).to.equal('27');
+    expect(queryParams.get('sort')).to.equal('downloads:desc,foo:asc');
   });
 
   it('properly generates a URLSearchParam with a page_type', async () => {
@@ -96,15 +102,15 @@ describe('SearchParams', () => {
     const params = {
       query,
       pageType: 'foo',
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&page_type=foo';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('page_type')).to.equal('foo');
   });
 
   it('properly generates a URLSearchParam with a page_type and page_target', async () => {
@@ -113,15 +119,16 @@ describe('SearchParams', () => {
       query,
       pageType: 'foo',
       pageTarget: 'bar',
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&page_type=foo&page_target=bar';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('page_type')).to.equal('foo');
+    expect(queryParams.get('page_target')).to.equal('bar');
   });
 
   it('properly generates a URLSearchParam with aggregations omitted', async () => {
@@ -131,15 +138,15 @@ describe('SearchParams', () => {
       aggregations: {
         omit: true,
       },
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&aggregations=false';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('aggregations')).to.equal('false');
   });
 
   it('properly generates a URLSearchParam with advanced aggregations', async () => {
@@ -159,15 +166,18 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&aggregations=%5B%7B%22terms%22%3A%7B%22field%22%3A%22foo%22%2C%22size%22%3A10%7D%7D%2C%7B%22terms%22%3A%7B%22field%22%3A%22bar%22%2C%22size%22%3A7%7D%7D%5D';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+
+    const expectedAggregationsParam =
+      '[{"terms":{"field":"foo","size":10}},{"terms":{"field":"bar","size":7}}]';
+    expect(queryParams.get('aggregations')).to.equal(expectedAggregationsParam);
   });
 
   it('properly generates a URLSearchParam with simple aggregations', async () => {
@@ -178,15 +188,15 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&aggregations=year%2Ccollection%2Csubject';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('aggregations')).to.equal('year,collection,subject');
   });
 
   it('properly generates a URLSearchParam with an aggregations_size param', async () => {
@@ -198,15 +208,16 @@ describe('SearchParams', () => {
       query,
       aggregations,
       aggregationsSize: 3,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&aggregations=year%2Ccollection%2Csubject&aggregations_size=3';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('aggregations')).to.equal('year,collection,subject');
+    expect(queryParams.get('aggregations_size')).to.equal('3');
   });
 
   it('advanced aggregations take precedence if both simple and advanced provided', async () => {
@@ -227,15 +238,18 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected =
-      'user_query=title%3Afoo+AND+collection%3Abar&aggregations=%5B%7B%22terms%22%3A%7B%22field%22%3A%22foo%22%2C%22size%22%3A10%7D%7D%2C%7B%22terms%22%3A%7B%22field%22%3A%22bar%22%2C%22size%22%3A7%7D%7D%5D';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+
+    const expectedAggregationsParam =
+      '[{"terms":{"field":"foo","size":10}},{"terms":{"field":"bar","size":7}}]';
+    expect(queryParams.get('aggregations')).to.equal(expectedAggregationsParam);
   });
 
   it('properly generates a URLSearchParam with debugging enabled', async () => {
@@ -243,29 +257,31 @@ describe('SearchParams', () => {
     const params = {
       query,
       debugging: true,
-      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected = 'user_query=title%3Afoo&debugging=true';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal('title:foo');
+    expect(queryParams.get('debugging')).to.equal('true');
   });
 
   it('properly generates a URLSearchParam with a uid', async () => {
     const query = 'title:foo';
     const params = {
       query,
-      uid: 'foobar',
-      includeClientUrl: false,
+      uid: 'boop',
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expected = 'user_query=title%3Afoo&uid=foobar';
-    expect(queryAsString).to.equal(expected);
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+    expect(queryParams.get('uid')).to.equal('boop');
   });
 
   it('properly generates a URLSearchParam with the client url by default', async () => {
@@ -277,9 +293,12 @@ describe('SearchParams', () => {
       params
     );
     const queryAsString = urlSearchParam.toString();
-    const expectedPrefix = 'user_query=title%3Afoo&client_url=http';
-    expect(queryAsString).to.satisfy((str: string) =>
-      str.startsWith(expectedPrefix)
-    );
+    const queryParams = new URL(`https://foo.bar/?${queryAsString}`)
+      .searchParams;
+    expect(queryParams.get('user_query')).to.equal(query);
+
+    // Don't rely on exact web-test-runner URLs, just verify the param was added and is a valid URL
+    expect(queryParams.get('client_url')).to.exist;
+    expect(new URL(queryParams.get('client_url')!)).not.to.throw;
   });
 });

--- a/test/search-params.test.ts
+++ b/test/search-params.test.ts
@@ -22,7 +22,7 @@ describe('SearchParams', () => {
 
   it('properly generates a URLSearchParam with just a query', async () => {
     const query = 'title:foo AND collection:bar';
-    const params = { query, includeClientUrl: false };
+    const params = { query };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );

--- a/test/search-params.test.ts
+++ b/test/search-params.test.ts
@@ -22,7 +22,7 @@ describe('SearchParams', () => {
 
   it('properly generates a URLSearchParam with just a query', async () => {
     const query = 'title:foo AND collection:bar';
-    const params = { query };
+    const params = { query, includeClientUrl: false };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
     );
@@ -37,6 +37,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       fields,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -57,6 +58,7 @@ describe('SearchParams', () => {
       rows: 53,
       page: 27,
       fields,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -78,6 +80,7 @@ describe('SearchParams', () => {
       sort,
       rows: 53,
       page: 27,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -93,6 +96,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       pageType: 'foo',
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -109,6 +113,7 @@ describe('SearchParams', () => {
       query,
       pageType: 'foo',
       pageTarget: 'bar',
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -126,6 +131,7 @@ describe('SearchParams', () => {
       aggregations: {
         omit: true,
       },
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -153,6 +159,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -171,6 +178,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -190,6 +198,7 @@ describe('SearchParams', () => {
       query,
       aggregations,
       aggregationsSize: 3,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -218,6 +227,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       aggregations,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -233,6 +243,7 @@ describe('SearchParams', () => {
     const params = {
       query,
       debugging: true,
+      includeClientUrl: false,
     };
     const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
       params
@@ -240,5 +251,35 @@ describe('SearchParams', () => {
     const queryAsString = urlSearchParam.toString();
     const expected = 'user_query=title%3Afoo&debugging=true';
     expect(queryAsString).to.equal(expected);
+  });
+
+  it('properly generates a URLSearchParam with a uid', async () => {
+    const query = 'title:foo';
+    const params = {
+      query,
+      uid: 'foobar',
+      includeClientUrl: false,
+    };
+    const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
+      params
+    );
+    const queryAsString = urlSearchParam.toString();
+    const expected = 'user_query=title%3Afoo&uid=foobar';
+    expect(queryAsString).to.equal(expected);
+  });
+
+  it('properly generates a URLSearchParam with the client url by default', async () => {
+    const query = 'title:foo';
+    const params = {
+      query,
+    };
+    const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
+      params
+    );
+    const queryAsString = urlSearchParam.toString();
+    const expectedPrefix = 'user_query=title%3Afoo&client_url=http';
+    expect(queryAsString).to.satisfy((str: string) =>
+      str.startsWith(expectedPrefix)
+    );
   });
 });


### PR DESCRIPTION
The PPS now handles a `uid` parameter that is returned unmodified in the response, which can be used to determine whether responses should be ignored as obsolete (i.e., from a previous search). Our current strategy for this is to compare the current query with the one in each response’s client_parameters, but this is unreliable since in some cases the backend may alter those in a normalization step. The `uid`, in contrast, is guaranteed to be returned-as-received.

The PPS also has tentative support for a `client_url` param which should contain the full URL that the search is originating from, to aid in debugging issues that arise on the PPS end.

This PR adds support for both of these params to the search service.