### PR TITLE
WEBDEV-5749 Add publicdate and reviewdate fields to item hit model

### DIFF
--- a/src/models/hit-types/item-hit.ts
+++ b/src/models/hit-types/item-hit.ts
@@ -279,6 +279,20 @@ export class ItemHit {
       : undefined;
   }
 
+  /** Optional. */
+  @Memoize() get publicdate(): typeof Metadata.prototype.publicdate {
+    return this.rawMetadata?.fields?.publicdate
+      ? new DateField(this.rawMetadata.fields.publicdate)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get reviewdate(): typeof Metadata.prototype.reviewdate {
+    return this.rawMetadata?.fields?.reviewdate
+      ? new DateField(this.rawMetadata.fields.reviewdate)
+      : undefined;
+  }
+
   /**
    * Format varies.
    * Optional.

--- a/test/models/hit-types/item-hit.test.ts
+++ b/test/models/hit-types/item-hit.test.ts
@@ -31,6 +31,8 @@ const fieldNames: (keyof ItemHit)[] = [
   'noindex',
   'num_favorites',
   'num_reviews',
+  'publicdate',
+  'reviewdate',
   'source',
   'subject',
   'title',
@@ -126,6 +128,8 @@ describe('ItemHit', () => {
     expect(hit.noindex?.value).to.be.undefined;
     expect(hit.num_favorites?.value).to.be.undefined;
     expect(hit.num_reviews?.value).to.be.undefined;
+    expect(hit.publicdate?.value).to.be.undefined;
+    expect(hit.reviewdate?.value).to.be.undefined;
     expect(hit.source?.value).to.be.undefined;
     expect(hit.type?.value).to.be.undefined;
     expect(hit.volume?.value).to.be.undefined;
@@ -165,6 +169,8 @@ describe('ItemHit', () => {
         noindex: true,
         num_favorites: 126,
         num_reviews: 127,
+        publicdate: '2011-07-20T00:00:00Z',
+        reviewdate: '2011-07-20T00:00:00Z',
         source: 'foo-source',
         type: 'foo-type',
         volume: 'foo-volume',


### PR DESCRIPTION
Until recently, the PPS only provided `publicdate` and `reviewdate` fields for full-text search hits, not metadata hits. However, these fields are now present on responses for both types of hits.

This PR adds those two fields to the metadata (ItemHit) model to make them readily accessible to clients.