### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/internetarchive/iaux-search-service/branch/master/graph/badge.svg?token=008OPP4BS1)](https://codecov.io/gh/internetarchive/iaux-search-service)
+
 # Internet Archive Search Service
 
 A service for searching the Internet Archive.


### PR DESCRIPTION
As pointed out in #28, this repo has been missing a codecov badge, and had the wrong default branch set for codecov analysis. The default branch has been fixed on codecov, and this PR adds the missing badge.