### PR TITLE
WEBDEV-5797 Add `caching` and `verbose` options

### DIFF
--- a/src/responses/search-request-params.ts
+++ b/src/responses/search-request-params.ts
@@ -20,4 +20,5 @@ export interface SearchRequestParams {
   sort?: string[];
   aggregations?: string[];
   aggregations_size?: number;
+  uid?: string;
 }

--- a/src/search-backend/base-search-backend.ts
+++ b/src/search-backend/base-search-backend.ts
@@ -22,6 +22,10 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
 
   protected requestScope?: string;
 
+  protected cachingFlags?: string;
+
+  protected verbose?: boolean;
+
   protected debuggingEnabled?: boolean;
 
   constructor(options?: SearchBackendOptionsInterface) {
@@ -40,14 +44,27 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
         null;
     }
 
+    const currentUrl = new URL(window.location.href);
+    const scopeParam = currentUrl.searchParams.get('scope');
+    const cachingParam = currentUrl.searchParams.get('caching');
+    const verboseParam = currentUrl.searchParams.get('verbose');
+
     if (options?.scope !== undefined) {
       this.requestScope = options.scope;
-    } else {
-      const currentUrl = new URL(window.location.href);
-      const scope = currentUrl.searchParams.get('scope');
-      if (scope) {
-        this.requestScope = scope;
-      }
+    } else if (scopeParam) {
+      this.requestScope = scopeParam;
+    }
+
+    if (options?.caching !== undefined) {
+      this.cachingFlags = options.caching;
+    } else if (cachingParam) {
+      this.cachingFlags = cachingParam;
+    }
+
+    if (options?.verbose !== undefined) {
+      this.verbose = options.verbose;
+    } else if (verboseParam) {
+      this.verbose = !!verboseParam;
     }
   }
 
@@ -72,6 +89,10 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
       finalUrl.searchParams.set('scope', this.requestScope);
     }
 
+    if (this.cachingFlags) {
+      finalUrl.searchParams.set('caching', this.cachingFlags);
+    }
+
     let response: Response;
     // first try the fetch and return a networkError if it fails
     try {
@@ -92,6 +113,10 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
     // then try json decoding and return a decodingError if it fails
     try {
       const json = await response.json();
+
+      if (this.verbose) {
+        this.printResponse(json);
+      }
 
       if (json.debugging) {
         this.printDebuggingInfo(json);
@@ -129,6 +154,43 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
     const error = new SearchServiceError(errorType, message, details);
     const result = { error };
     return result;
+  }
+
+  /**
+   * Logs a full response to the console, with truncated hits.
+   */
+  private printResponse(json: Record<string, any>) {
+    try {
+      const clonedResponse = JSON.parse(JSON.stringify(json));
+
+      // Keep at most the first hit, and throw away the rest
+      const hits = clonedResponse?.response?.body?.hits?.hits;
+      if (Array.isArray(hits) && hits.length > 1) {
+        const newHits = [];
+        newHits.push(hits[0]);
+        newHits.push(`*** ${hits.length - 1} hits omitted ***`);
+        clonedResponse.response.body.hits.hits = newHits;
+      }
+
+      // Keep the aggregation keys but throw away their buckets
+      const aggregations = clonedResponse?.response?.body?.aggregations;
+      if (aggregations) {
+        Object.entries(aggregations).forEach(([key, val]) => {
+          if ((val as any)?.buckets?.length > 0) {
+            const clonedVal = JSON.parse(JSON.stringify(val));
+            clonedVal.buckets = `*** ${
+              clonedVal.buckets?.length ?? 0
+            } buckets omitted ***`;
+            clonedResponse.response.body.aggregations[key] = clonedVal;
+          }
+        });
+      }
+
+      console.log(`\n\n***** RESPONSE RECEIVED *****`);
+      console.log(JSON.stringify(clonedResponse, null, 2));
+    } catch (err) {
+      console.error('Error printing search response:', err);
+    }
   }
 
   /**

--- a/src/search-backend/base-search-backend.ts
+++ b/src/search-backend/base-search-backend.ts
@@ -186,8 +186,10 @@ export abstract class BaseSearchBackend implements SearchBackendInterface {
         });
       }
 
-      console.log(`\n\n***** RESPONSE RECEIVED *****`);
+      console.log(`***** RESPONSE RECEIVED *****`);
+      console.groupCollapsed('Response');
       console.log(JSON.stringify(clonedResponse, null, 2));
+      console.groupEnd();
     } catch (err) {
       console.error('Error printing search response:', err);
     }

--- a/src/search-backend/search-backend-options.ts
+++ b/src/search-backend/search-backend-options.ts
@@ -7,8 +7,35 @@ export interface SearchBackendOptionsInterface {
    * Defaults to 'archive.org'.
    */
   baseUrl?: string;
+
+  /**
+   * The path the to the backend service to send requests to, at the base URL.
+   */
   servicePath?: string;
+
+  /**
+   * Whether to include credentials in the request.
+   * Only works when not blocked by CORS policy.
+   */
   includeCredentials?: boolean;
+
+  /**
+   * The request scope to send to the PPS.
+   */
   scope?: string;
+
+  /**
+   * Optional caching requests to the backend, e.g. to bypass or recompute the cache
+   */
+  caching?: string;
+
+  /**
+   * Whether debugging info should be requested and logged when present on a response
+   */
   debuggingEnabled?: boolean;
+
+  /**
+   * Whether the full response details should be logged for every response
+   */
+  verbose?: boolean;
 }

--- a/src/search-service.ts
+++ b/src/search-service.ts
@@ -49,8 +49,13 @@ export class SearchService implements SearchServiceInterface {
    */
   @Memoize((type: SearchType, options: SearchBackendOptionsInterface = {}) => {
     // We can memoize backends based on their params, to avoid constructing redundant backends
-    const { includeCredentials = '', scope = '', baseUrl = '' } = options;
-    return `${type};${includeCredentials};${scope};${baseUrl}`;
+    const {
+      includeCredentials = false,
+      verbose = false,
+      scope = '',
+      baseUrl = '',
+    } = options;
+    return `${type};${includeCredentials};${verbose};${scope};${baseUrl}`;
   })
   static getBackendForSearchType(
     type: SearchType,

--- a/test/models/aggregation.test.ts
+++ b/test/models/aggregation.test.ts
@@ -1,0 +1,101 @@
+import { expect } from '@open-wc/testing';
+import {
+  Aggregation,
+  AggregationSortType,
+  Bucket,
+} from '../../src/models/aggregation';
+
+describe('Aggregation model', () => {
+  it('constructs with options', () => {
+    const buckets = [1, 2, 3, 4];
+    const doc_count_error_upper_bound = 10;
+    const sum_other_doc_count = 20;
+    const first_bucket_key = 0;
+    const last_bucket_key = 3;
+    const number_buckets = 4;
+    const interval = 1;
+
+    const agg = new Aggregation({
+      buckets,
+      doc_count_error_upper_bound,
+      sum_other_doc_count,
+      first_bucket_key,
+      last_bucket_key,
+      number_buckets,
+      interval,
+    });
+
+    expect(agg.buckets).to.equal(buckets);
+    expect(agg.doc_count_error_upper_bound).to.equal(
+      doc_count_error_upper_bound
+    );
+    expect(agg.sum_other_doc_count).to.equal(sum_other_doc_count);
+    expect(agg.first_bucket_key).to.equal(first_bucket_key);
+    expect(agg.last_bucket_key).to.equal(last_bucket_key);
+    expect(agg.number_buckets).to.equal(number_buckets);
+    expect(agg.interval).to.equal(interval);
+  });
+
+  it('expects default sorted buckets by count', async () => {
+    const buckets: Bucket[] = [
+      { key: 'a', doc_count: 5 },
+      { key: 'e', doc_count: 4 },
+      { key: 'b', doc_count: 3 },
+      { key: 'c', doc_count: 2 },
+      { key: 'd', doc_count: 1 },
+    ];
+    const agg = new Aggregation({ buckets });
+
+    expect(agg.getSortedBuckets(AggregationSortType.COUNT)).to.deep.equal(
+      buckets
+    );
+  });
+
+  it('sorts buckets alphabetically', async () => {
+    const buckets: Bucket[] = [
+      { key: 'e', doc_count: 4 },
+      { key: 'c', doc_count: 2 },
+      { key: 'b', doc_count: 3 },
+      { key: 'd', doc_count: 1 },
+      { key: 'a', doc_count: 5 },
+    ];
+    const agg = new Aggregation({ buckets });
+
+    expect(
+      agg.getSortedBuckets(AggregationSortType.ALPHABETICAL)
+    ).to.deep.equal([
+      { key: 'a', doc_count: 5 },
+      { key: 'b', doc_count: 3 },
+      { key: 'c', doc_count: 2 },
+      { key: 'd', doc_count: 1 },
+      { key: 'e', doc_count: 4 },
+    ]);
+  });
+
+  it('sorts buckets numerically', async () => {
+    const buckets: Bucket[] = [
+      { key: 400, doc_count: 4 },
+      { key: 1999, doc_count: 2 },
+      { key: 1001, doc_count: 3 },
+      { key: 1900, doc_count: 1 },
+      { key: 2005, doc_count: 5 },
+    ];
+    const agg = new Aggregation({ buckets });
+
+    expect(agg.getSortedBuckets(AggregationSortType.NUMERIC)).to.deep.equal([
+      { key: 2005, doc_count: 5 },
+      { key: 1999, doc_count: 2 },
+      { key: 1900, doc_count: 1 },
+      { key: 1001, doc_count: 3 },
+      { key: 400, doc_count: 4 },
+    ]);
+  });
+
+  it('does not sort raw number buckets', async () => {
+    const buckets: number[] = [3, 5, 2, 4, 1];
+    const agg = new Aggregation({ buckets });
+    expect(agg.getSortedBuckets(AggregationSortType.COUNT)).to.deep.equal(
+      buckets
+    );
+  });
+});

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -76,13 +76,18 @@ describe('FulltextSearchBackend', () => {
     });
 
     it('includes scope param from URL if not provided', async () => {
-      window.location.search = `?scope=boop`;
+      const url = new URL(window.location.href);
+      url.searchParams.set('scope', 'boop');
+      window.history.replaceState({}, '', url.toString());
 
       const backend = new FulltextSearchBackend();
       await backend.performSearch({ query: 'foo' });
 
       const queryParams = new URL(urlCalled!.toString()).searchParams;
       expect(queryParams.get('scope')).to.equal('boop');
+
+      url.searchParams.delete('scope');
+      window.history.replaceState({}, '', url.toString());
     });
 
     it('includes caching param if provided', async () => {
@@ -98,13 +103,19 @@ describe('FulltextSearchBackend', () => {
 
     it('includes caching param from URL if not provided', async () => {
       const cachingParam = JSON.stringify({ bypass: true });
-      window.location.search = `?caching=${cachingParam}`;
+
+      const url = new URL(window.location.href);
+      url.searchParams.set('caching', cachingParam);
+      window.history.replaceState({}, '', url.toString());
 
       const backend = new FulltextSearchBackend();
       await backend.performSearch({ query: 'foo' });
 
       const queryParams = new URL(urlCalled!.toString()).searchParams;
       expect(queryParams.get('caching')).to.equal(cachingParam);
+
+      url.searchParams.delete('caching');
+      window.history.replaceState({}, '', url.toString());
     });
 
     it('can enable debugging by default on all searches', async () => {
@@ -254,7 +265,7 @@ describe('FulltextSearchBackend', () => {
     });
 
     expect(logSpy.callCount).to.be.greaterThan(0);
-    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
     expect(logSpy.args[1][0]).to.equal(JSON.stringify(expectedLogObj, null, 2));
 
     window.fetch = fetchBackup;
@@ -262,7 +273,9 @@ describe('FulltextSearchBackend', () => {
   });
 
   it('includes verbose param from URL if not provided', async () => {
-    window.location.search = `?verbose=1`;
+    const url = new URL(window.location.href);
+    url.searchParams.set('verbose', '1');
+    window.history.replaceState({}, '', url.toString());
 
     const logBackup = console.log;
     const logSpy = Sinon.spy();
@@ -272,8 +285,10 @@ describe('FulltextSearchBackend', () => {
     await backend.performSearch({ query: 'foo' });
 
     expect(logSpy.callCount).to.be.greaterThan(0);
-    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
 
     console.log = logBackup;
+    url.searchParams.delete('verbose');
+    window.history.replaceState({}, '', url.toString());
   });
 });

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -75,6 +75,17 @@ describe('FulltextSearchBackend', () => {
       expect(urlConfig?.credentials).to.equal('include');
     });
 
+    it('includes caching param if provided', async () => {
+      const cachingParam = JSON.stringify({ bypass: true });
+      const backend = new FulltextSearchBackend({
+        caching: cachingParam,
+      });
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal(cachingParam);
+    });
+
     it('can enable debugging by default on all searches', async () => {
       const backend = new FulltextSearchBackend({
         baseUrl: 'foo.bar',

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -75,11 +75,32 @@ describe('FulltextSearchBackend', () => {
       expect(urlConfig?.credentials).to.equal('include');
     });
 
+    it('includes scope param from URL if not provided', async () => {
+      window.location.search = `?scope=boop`;
+
+      const backend = new FulltextSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('scope')).to.equal('boop');
+    });
+
     it('includes caching param if provided', async () => {
       const cachingParam = JSON.stringify({ bypass: true });
       const backend = new FulltextSearchBackend({
         caching: cachingParam,
       });
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal(cachingParam);
+    });
+
+    it('includes caching param from URL if not provided', async () => {
+      const cachingParam = JSON.stringify({ bypass: true });
+      window.location.search = `?caching=${cachingParam}`;
+
+      const backend = new FulltextSearchBackend();
       await backend.performSearch({ query: 'foo' });
 
       const queryParams = new URL(urlCalled!.toString()).searchParams;
@@ -237,6 +258,22 @@ describe('FulltextSearchBackend', () => {
     expect(logSpy.args[1][0]).to.equal(JSON.stringify(expectedLogObj, null, 2));
 
     window.fetch = fetchBackup;
+    console.log = logBackup;
+  });
+
+  it('includes verbose param from URL if not provided', async () => {
+    window.location.search = `?verbose=1`;
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new FulltextSearchBackend();
+    await backend.performSearch({ query: 'foo' });
+
+    expect(logSpy.callCount).to.be.greaterThan(0);
+    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+
     console.log = logBackup;
   });
 });

--- a/test/search-backend/fulltext-search-backend.test.ts
+++ b/test/search-backend/fulltext-search-backend.test.ts
@@ -273,6 +273,11 @@ describe('FulltextSearchBackend', () => {
   });
 
   it('includes verbose param from URL if not provided', async () => {
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(JSON.stringify({}));
+    };
+
     const url = new URL(window.location.href);
     url.searchParams.set('verbose', '1');
     window.history.replaceState({}, '', url.toString());
@@ -287,6 +292,7 @@ describe('FulltextSearchBackend', () => {
     expect(logSpy.callCount).to.be.greaterThan(0);
     expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
 
+    window.fetch = fetchBackup;
     console.log = logBackup;
     url.searchParams.delete('verbose');
     window.history.replaceState({}, '', url.toString());

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -273,6 +273,11 @@ describe('MetadataSearchBackend', () => {
   });
 
   it('includes verbose param from URL if not provided', async () => {
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(JSON.stringify({}));
+    };
+
     const url = new URL(window.location.href);
     url.searchParams.set('verbose', '1');
     window.history.replaceState({}, '', url.toString());
@@ -287,6 +292,7 @@ describe('MetadataSearchBackend', () => {
     expect(logSpy.callCount).to.be.greaterThan(0);
     expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
 
+    window.fetch = fetchBackup;
     console.log = logBackup;
     url.searchParams.delete('verbose');
     window.history.replaceState({}, '', url.toString());

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -75,6 +75,17 @@ describe('MetadataSearchBackend', () => {
       expect(urlConfig?.credentials).to.equal('include');
     });
 
+    it('includes caching param if provided', async () => {
+      const cachingParam = JSON.stringify({ bypass: true });
+      const backend = new MetadataSearchBackend({
+        caching: cachingParam,
+      });
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal(cachingParam);
+    });
+
     it('can enable debugging by default on all searches', async () => {
       const backend = new MetadataSearchBackend({
         baseUrl: 'foo.bar',

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -76,13 +76,18 @@ describe('MetadataSearchBackend', () => {
     });
 
     it('includes scope param from URL if not provided', async () => {
-      window.location.search = `?scope=boop`;
+      const url = new URL(window.location.href);
+      url.searchParams.set('scope', 'boop');
+      window.history.replaceState({}, '', url.toString());
 
       const backend = new MetadataSearchBackend();
       await backend.performSearch({ query: 'foo' });
 
       const queryParams = new URL(urlCalled!.toString()).searchParams;
       expect(queryParams.get('scope')).to.equal('boop');
+
+      url.searchParams.delete('scope');
+      window.history.replaceState({}, '', url.toString());
     });
 
     it('includes caching param if provided', async () => {
@@ -98,13 +103,19 @@ describe('MetadataSearchBackend', () => {
 
     it('includes caching param from URL if not provided', async () => {
       const cachingParam = JSON.stringify({ bypass: true });
-      window.location.search = `?caching=${cachingParam}`;
+
+      const url = new URL(window.location.href);
+      url.searchParams.set('caching', cachingParam);
+      window.history.replaceState({}, '', url.toString());
 
       const backend = new MetadataSearchBackend();
       await backend.performSearch({ query: 'foo' });
 
       const queryParams = new URL(urlCalled!.toString()).searchParams;
       expect(queryParams.get('caching')).to.equal(cachingParam);
+
+      url.searchParams.delete('caching');
+      window.history.replaceState({}, '', url.toString());
     });
 
     it('can enable debugging by default on all searches', async () => {
@@ -254,7 +265,7 @@ describe('MetadataSearchBackend', () => {
     });
 
     expect(logSpy.callCount).to.be.greaterThan(0);
-    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
     expect(logSpy.args[1][0]).to.equal(JSON.stringify(expectedLogObj, null, 2));
 
     window.fetch = fetchBackup;
@@ -262,7 +273,9 @@ describe('MetadataSearchBackend', () => {
   });
 
   it('includes verbose param from URL if not provided', async () => {
-    window.location.search = `?verbose=1`;
+    const url = new URL(window.location.href);
+    url.searchParams.set('verbose', '1');
+    window.history.replaceState({}, '', url.toString());
 
     const logBackup = console.log;
     const logSpy = Sinon.spy();
@@ -272,8 +285,10 @@ describe('MetadataSearchBackend', () => {
     await backend.performSearch({ query: 'foo' });
 
     expect(logSpy.callCount).to.be.greaterThan(0);
-    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
 
     console.log = logBackup;
+    url.searchParams.delete('verbose');
+    window.history.replaceState({}, '', url.toString());
   });
 });

--- a/test/search-backend/metadata-search-backend.test.ts
+++ b/test/search-backend/metadata-search-backend.test.ts
@@ -175,4 +175,57 @@ describe('MetadataSearchBackend', () => {
     window.fetch = fetchBackup;
     console.log = logBackup;
   });
+
+  it('logs response to console if verbose=true', async () => {
+    const responseObj = {
+      response: {
+        body: {
+          hits: {
+            hits: ['h1', 'h2', 'h3', 'h4', 'h5'],
+          },
+          aggregations: {
+            creator: {
+              buckets: ['c1', 'c2', 'c3', 'c4', 'c5'],
+            },
+          },
+        },
+      },
+    };
+
+    const expectedLogObj = {
+      response: {
+        body: {
+          hits: {
+            hits: ['h1', '*** 4 hits omitted ***'],
+          },
+          aggregations: {
+            creator: {
+              buckets: '*** 5 buckets omitted ***',
+            },
+          },
+        },
+      },
+    };
+
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(JSON.stringify(responseObj));
+    };
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new MetadataSearchBackend({ verbose: true });
+    await backend.performSearch({
+      query: 'boop',
+    });
+
+    expect(logSpy.callCount).to.be.greaterThan(0);
+    expect(logSpy.args[0][0]).to.equal('\n\n***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[1][0]).to.equal(JSON.stringify(expectedLogObj, null, 2));
+
+    window.fetch = fetchBackup;
+    console.log = logBackup;
+  });
 });


### PR DESCRIPTION
This PR adds support for the `caching` and `verbose` options on search service backend instances.

The `caching` option indicates flags for the PPS to modify how the request interacts with the cache. The `verbose` option indicates whether all responses from the backend should be logged to the console (with some elements truncated, such as the `hits` array and aggregation buckets).

Both options are passed through automatically from the page URL if present and not otherwise specified.