### PR TITLE
WEBDEV-5842 Add `collectionTitles` property to match new PPS responses

### DIFF
--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -11,6 +11,7 @@ import type { SearchHitSchema } from './search-hit-schema';
 export interface SearchResponseBody {
   hits: SearchResponseHits;
   aggregations?: Record<string, Aggregation>;
+  collection_titles?: Record<string, string>;
 }
 
 /**
@@ -53,6 +54,12 @@ export class SearchResponseDetails {
   aggregations?: Record<string, Aggregation>;
 
   /**
+   * A map from collection identifiers (those present on the hits/aggregations)
+   * to their titles.
+   */
+  collectionTitles?: Record<string, string>;
+
+  /**
    * The hit schema for this response
    */
   schema?: SearchHitSchema;
@@ -77,6 +84,10 @@ export class SearchResponseDetails {
         },
         {} as Record<string, Aggregation>
       );
+    }
+
+    if (body?.collection_titles) {
+      this.collectionTitles = body.collection_titles;
     }
   }
 

--- a/test/responses/search-response-details.test.ts
+++ b/test/responses/search-response-details.test.ts
@@ -1,32 +1,39 @@
 import { expect } from '@open-wc/testing';
+import { Aggregation } from '../../src/models/aggregation';
 import { HitType } from '../../src/models/hit-types/hit';
 import { ItemHit } from '../../src/models/hit-types/item-hit';
 import { TextHit } from '../../src/models/hit-types/text-hit';
-import { SearchResponseDetails } from '../../src/responses/search-response-details';
+import {
+  SearchResponseBody,
+  SearchResponseDetails,
+} from '../../src/responses/search-response-details';
+
+const responseBody: SearchResponseBody = {
+  hits: {
+    total: 2,
+    returned: 2,
+    hits: [
+      {
+        fields: {
+          identifier: 'foo',
+          mediatype: 'texts',
+        },
+      },
+      {
+        fields: {
+          identifier: 'bar',
+          collection: ['baz'],
+        },
+      },
+    ],
+  },
+  collection_titles: {
+    baz: 'Baz Collection',
+  },
+};
 
 describe('SearchResponseDetails', () => {
   it('constructs item hits', () => {
-    const responseBody = {
-      hits: {
-        total: 2,
-        returned: 2,
-        hits: [
-          {
-            fields: {
-              identifier: 'foo',
-              mediatype: 'texts',
-            },
-          },
-          {
-            fields: {
-              identifier: 'bar',
-              collection: ['baz'],
-            },
-          },
-        ],
-      },
-    };
-
     const responseSchema = {
       hit_type: 'item' as HitType,
       field_properties: {},
@@ -42,27 +49,6 @@ describe('SearchResponseDetails', () => {
   });
 
   it('constructs text hits', () => {
-    const responseBody = {
-      hits: {
-        total: 2,
-        returned: 2,
-        hits: [
-          {
-            fields: {
-              identifier: 'foo',
-              mediatype: 'texts',
-            },
-          },
-          {
-            fields: {
-              identifier: 'bar',
-              collection: ['baz'],
-            },
-          },
-        ],
-      },
-    };
-
     const responseSchema = {
       hit_type: 'text' as HitType,
       field_properties: {},
@@ -75,5 +61,74 @@ describe('SearchResponseDetails', () => {
     expect(details.results[0].creator?.value).to.be.undefined;
     expect(details.results[1].identifier).to.equal('bar');
     expect(details.results[1].collection?.value).to.equal('baz');
+  });
+
+  it('includes aggregations', () => {
+    const aggsResponseBody: SearchResponseBody = {
+      hits: {
+        total: 0,
+        returned: 0,
+        hits: [],
+      },
+      aggregations: {
+        foo: new Aggregation({
+          buckets: [
+            {
+              key: 'bar',
+              doc_count: 10,
+            },
+          ],
+        }),
+      },
+    };
+
+    const responseSchema = {
+      hit_type: 'item' as HitType,
+      field_properties: {},
+    };
+
+    const details = new SearchResponseDetails(aggsResponseBody, responseSchema);
+    expect(details.results.length).to.equal(0);
+    expect(details.aggregations).to.deep.equal({
+      foo: new Aggregation({
+        buckets: [
+          {
+            key: 'bar',
+            doc_count: 10,
+          },
+        ],
+      }),
+    });
+  });
+
+  it('provides access to collection titles map', () => {
+    const responseSchema = {
+      hit_type: 'item' as HitType,
+      field_properties: {},
+    };
+
+    const details = new SearchResponseDetails(responseBody, responseSchema);
+    expect(details.results.length).to.equal(2);
+    expect(details.collectionTitles).to.deep.equal({ baz: 'Baz Collection' });
+  });
+
+  it('collection titles map is optional', () => {
+    const responseBodyWithoutTitles = Object.assign(
+      {},
+      responseBody
+    ) as SearchResponseBody;
+    delete responseBodyWithoutTitles.collection_titles;
+
+    const responseSchema = {
+      hit_type: 'item' as HitType,
+      field_properties: {},
+    };
+
+    const details = new SearchResponseDetails(
+      responseBodyWithoutTitles,
+      responseSchema
+    );
+    expect(details.results.length).to.equal(2);
+    expect(details.collectionTitles).to.be.undefined;
   });
 });


### PR DESCRIPTION
This PR adds a `collectionTitles` property to `SearchResponseDetails` objects, which optionally contains any collection titles object found on the response. The PPS has recently been upgraded to include such an object on hits/aggregations requests, containing a mapping from any collection identifiers to their readable titles.