### PR TITLE
Fix a typo in contributor_details field

### DIFF
--- a/src/responses/collection-extra-info.ts
+++ b/src/responses/collection-extra-info.ts
@@ -12,7 +12,7 @@ export interface CollectionExtraInfo {
   collection_size?: number;
 
   /** User details for each of the "Additional Contributors" to this collection */
-  contributors_details?: UserDetails[];
+  contributor_details?: UserDetails[];
 
   /** How many total views this collection has received (all-time) */
   downloads?: number;


### PR DESCRIPTION
The PPS uses `contributor_details` with singular contributor. Current search service field has an extra 's'.