### PR TITLE
WEBDEV-6697 Add `session_context` to response model

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ export {
 
 export { SearchResponse } from './src/responses/search-response';
 export { SearchResponseHeader } from './src/responses/search-response-header';
+export { SearchResponseSessionContext } from './src/responses/search-response-session-context';
 export { SearchResponseParams } from './src/responses/search-response-params';
 export {
   CollectionExtraInfo,

--- a/src/responses/search-response-session-context.ts
+++ b/src/responses/search-response-session-context.ts
@@ -1,0 +1,17 @@
+export interface SearchResponseSessionContext {
+  username: string;
+  authentication_method: string;
+  is_system: boolean;
+  is_guest: boolean;
+  is_user: boolean;
+  is_archive_user: boolean;
+  is_qualified: boolean;
+  has_universal_privs: boolean;
+  has_allowed_host_priv: boolean;
+  has_scan_center_priv: boolean;
+  has_any_priv: boolean;
+  pps: {
+    is_page_target_owner: boolean;
+    full_text_search_override: boolean;
+  }
+}

--- a/src/responses/search-response-session-context.ts
+++ b/src/responses/search-response-session-context.ts
@@ -1,17 +1,17 @@
 export interface SearchResponseSessionContext {
-  username: string;
-  authentication_method: string;
-  is_system: boolean;
-  is_guest: boolean;
-  is_user: boolean;
-  is_archive_user: boolean;
-  is_qualified: boolean;
-  has_universal_privs: boolean;
-  has_allowed_host_priv: boolean;
-  has_scan_center_priv: boolean;
-  has_any_priv: boolean;
-  pps: {
-    is_page_target_owner: boolean;
-    full_text_search_override: boolean;
+  username?: string;
+  authentication_method?: string;
+  is_system?: boolean;
+  is_guest?: boolean;
+  is_user?: boolean;
+  is_archive_user?: boolean;
+  is_qualified?: boolean;
+  has_universal_privs?: boolean;
+  has_allowed_host_priv?: boolean;
+  has_scan_center_priv?: boolean;
+  has_any_priv?: boolean;
+  pps?: {
+    is_page_target_owner?: boolean;
+    full_text_search_override?: boolean;
   }
 }

--- a/src/responses/search-response-session-context.ts
+++ b/src/responses/search-response-session-context.ts
@@ -13,5 +13,5 @@ export interface SearchResponseSessionContext {
   pps?: {
     is_page_target_owner?: boolean;
     full_text_search_override?: boolean;
-  }
+  };
 }

--- a/src/responses/search-response.ts
+++ b/src/responses/search-response.ts
@@ -5,6 +5,7 @@ import {
   SearchResponseDetails,
 } from './search-response-details';
 import { SearchRequest } from './search-request';
+import { SearchResponseSessionContext } from './search-response-session-context';
 
 /**
  * The top-level response model when retrieving a response from the page production service endpoint.
@@ -36,6 +37,11 @@ export class SearchResponse {
   responseHeader: SearchResponseHeader;
 
   /**
+   * The session context from the PPS
+   */
+  sessionContext: SearchResponseSessionContext;
+
+  /**
    * The response containing the search results
    *
    * @type {SearchResponseDetailsInterface}
@@ -47,6 +53,7 @@ export class SearchResponse {
     this.rawResponse = json;
     this.request = new SearchRequest(json.request);
     this.responseHeader = json.response?.header;
+    this.sessionContext = json.session_context;
     this.response = new SearchResponseDetails(
       json.response?.body,
       json.response?.hit_schema


### PR DESCRIPTION
Exposes the `session_context` branch of PPS responses on the response model returned from searches. Notably, this provides access to the `full_text_search_override` key needed to enable FTS on collections for priv'd users.