### PR TITLE
WEBDEV-7033 Add federated search to search service

### DIFF
--- a/src/models/hit-types/hit.ts
+++ b/src/models/hit-types/hit.ts
@@ -2,6 +2,7 @@ import type { ItemHit } from './item-hit';
 import type { TextHit } from './text-hit';
 import type { FavoritedSearchHit } from './favorited-search-hit';
 import { WebArchiveHit } from './web-archive-hit';
+import type { TvClipHit } from './tv-clip-hit';
 
 /**
  * Union of the different hit_type values returned by the PPS.
@@ -12,7 +13,8 @@ export type HitType =
   | 'text'
   | 'asr_text'
   | 'favorited_search'
-  | 'web_archive';
+  | 'web_archive'
+  | 'tv_clip';
 
 /**
  * Additional information provided by the PPS about hits, separately from
@@ -27,7 +29,11 @@ interface HitInfo {
 /**
  * Type that includes all the fields present on any type of hit
  */
-type AllHitFields = ItemHit & TextHit & FavoritedSearchHit & WebArchiveHit;
+type AllHitFields = ItemHit &
+  TextHit &
+  FavoritedSearchHit &
+  WebArchiveHit &
+  TvClipHit;
 
 /**
  * Result is an expansive type definition encompassing all the optional

--- a/src/models/hit-types/tv-clip-hit.ts
+++ b/src/models/hit-types/tv-clip-hit.ts
@@ -58,8 +58,10 @@ export class TvClipHit {
 
   /** Optional. */
   @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
-    return this.rawMetadata?.fields?.avg_rating != null
-      ? new NumberField(this.rawMetadata.fields.avg_rating)
+    const averageRating = this.rawMetadata?.fields?.avg_rating;
+
+    return averageRating || averageRating === 0
+      ? new NumberField(this.rawMetadata?.fields.avg_rating)
       : undefined;
   }
 
@@ -109,8 +111,10 @@ export class TvClipHit {
    * Optional.
    */
   @Memoize() get downloads(): typeof Metadata.prototype.downloads {
-    return this.rawMetadata?.fields?.downloads != null
-      ? new NumberField(this.rawMetadata.fields.downloads)
+    const downloads = this.rawMetadata?.fields?.downloads;
+
+    return downloads || downloads === 0
+      ? new NumberField(this.rawMetadata?.fields.downloads)
       : undefined;
   }
 
@@ -127,8 +131,10 @@ export class TvClipHit {
   }
 
   @Memoize() get file_creation_mtime(): NumberField | undefined {
-    return this.rawMetadata?.fields?.file_creation_mtime != null
-      ? new NumberField(this.rawMetadata.fields.file_creation_mtime)
+    const mTime = this.rawMetadata?.fields?.file_creation_mtime;
+
+    return mTime || mTime === 0
+      ? new NumberField(this.rawMetadata?.fields.file_creation_mtime)
       : undefined;
   }
 
@@ -160,8 +166,10 @@ export class TvClipHit {
    * Potentially irrelevant for TVS hit.
    */
   @Memoize() get result_in_subfile(): BooleanField | undefined {
-    return this.rawMetadata?.fields?.result_in_subfile != null
-      ? new BooleanField(this.rawMetadata.fields.result_in_subfile)
+    const resultInSubfile = this.rawMetadata?.fields?.result_in_subfile;
+
+    return resultInSubfile || resultInSubfile === false
+      ? new BooleanField(this.rawMetadata?.fields.result_in_subfile)
       : undefined;
   }
 
@@ -210,8 +218,10 @@ export class TvClipHit {
    * Optional.
    */
   @Memoize() get year(): NumberField | undefined {
-    return this.rawMetadata?.fields?.year != null
-      ? new NumberField(this.rawMetadata.fields.year)
+    const year = this.rawMetadata?.fields?.year;
+
+    return year || year === 0
+      ? new NumberField(this.rawMetadata?.fields.year)
       : undefined;
   }
 
@@ -220,8 +230,10 @@ export class TvClipHit {
    * Start time for TV hit.
    */
   @Memoize() get start(): StringField | undefined {
-    return this.rawMetadata?.fields?.start != null
-      ? new StringField(this.rawMetadata.fields.start)
+    const start = this.rawMetadata?.fields?.start;
+
+    return start || start === 0
+      ? new StringField(this.rawMetadata?.fields.start)
       : undefined;
   }
 

--- a/src/models/hit-types/tv-clip-hit.ts
+++ b/src/models/hit-types/tv-clip-hit.ts
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Memoize } from 'typescript-memoize';
+import type { Metadata } from '../metadata';
+import { BooleanField } from '../metadata-fields/field-types/boolean';
+import { DateField } from '../metadata-fields/field-types/date';
+import { MediaTypeField } from '../metadata-fields/field-types/mediatype';
+import { NumberField } from '../metadata-fields/field-types/number';
+import { StringField } from '../metadata-fields/field-types/string';
+
+/**
+ * A model that describes a TV clip hit from a TV search via the PPS endpoint.
+ *
+ * The fields in here are cast to their respective field types. See `metadata-fields/field-type`.
+ *
+ * Add additional fields as needed.
+ *
+ * @export
+ * @class TvClipHit
+ */
+export class TvClipHit {
+  /**
+   * This is the raw hit response; useful for inspecting the raw data
+   * returned from the server.
+   */
+  rawMetadata?: Record<string, any>;
+
+  constructor(json: Record<string, any>) {
+    this.rawMetadata = json;
+  }
+
+  /**
+   * The item identifier.
+   *
+   * _Note_: This is a plain string instead of a `MetadataField` since it's
+   * the primary key of the item.
+   */
+  get identifier(): typeof Metadata.prototype.identifier {
+    return this.rawMetadata?.fields?.identifier;
+  }
+
+  /**
+   * Synthesized in processing of TVS API hit; TBD
+   * Optional.
+   */
+  @Memoize() get highlight(): StringField | undefined {
+    // Note: _not_ inside the fields object.
+    return this.rawMetadata?.highlight?.text
+      ? new StringField(this.rawMetadata.highlight.text)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get addeddate(): typeof Metadata.prototype.addeddate {
+    return this.rawMetadata?.fields?.addeddate
+      ? new DateField(this.rawMetadata.fields.addeddate)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get avg_rating(): typeof Metadata.prototype.avg_rating {
+    return this.rawMetadata?.fields?.avg_rating != null
+      ? new NumberField(this.rawMetadata.fields.avg_rating)
+      : undefined;
+  }
+
+  /** Multivalued. */
+  @Memoize() get collection(): typeof Metadata.prototype.collection {
+    return this.rawMetadata?.fields?.collection
+      ? new StringField(this.rawMetadata.fields.collection)
+      : undefined;
+  }
+
+  @Memoize() get created_on(): DateField | undefined {
+    return this.rawMetadata?.fields?.created_on
+      ? new DateField(this.rawMetadata.fields.created_on)
+      : undefined;
+  }
+
+  /**
+   * Optional.
+   * Multivalued.
+   */
+  @Memoize() get creator(): typeof Metadata.prototype.creator {
+    return this.rawMetadata?.fields?.creator
+      ? new StringField(this.rawMetadata.fields.creator)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get date(): typeof Metadata.prototype.date {
+    return this.rawMetadata?.fields?.date
+      ? new DateField(this.rawMetadata.fields.date)
+      : undefined;
+  }
+
+  /**
+   * Contents of description in TVS API hit, TBD
+   * Optional.
+   * Multivalued.
+   */
+  @Memoize() get description(): typeof Metadata.prototype.description {
+    return this.rawMetadata?.fields?.description
+      ? new StringField(this.rawMetadata.fields.description)
+      : undefined;
+  }
+
+  /**
+   * Total views over ITEM (not text) lifetime, updated by audit consultation with Views API.
+   * Optional.
+   */
+  @Memoize() get downloads(): typeof Metadata.prototype.downloads {
+    return this.rawMetadata?.fields?.downloads != null
+      ? new NumberField(this.rawMetadata.fields.downloads)
+      : undefined;
+  }
+
+  @Memoize() get filename(): StringField | undefined {
+    return this.rawMetadata?.fields?.filename
+      ? new StringField(this.rawMetadata.fields.filename)
+      : undefined;
+  }
+
+  @Memoize() get file_basename(): StringField | undefined {
+    return this.rawMetadata?.fields?.file_basename
+      ? new StringField(this.rawMetadata.fields.file_basename)
+      : undefined;
+  }
+
+  @Memoize() get file_creation_mtime(): NumberField | undefined {
+    return this.rawMetadata?.fields?.file_creation_mtime != null
+      ? new NumberField(this.rawMetadata.fields.file_creation_mtime)
+      : undefined;
+  }
+
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get issue(): typeof Metadata.prototype.issue {
+    return this.rawMetadata?.fields?.issue
+      ? new StringField(this.rawMetadata.fields.issue)
+      : undefined;
+  }
+
+  @Memoize() get mediatype(): typeof Metadata.prototype.mediatype {
+    return this.rawMetadata?.fields?.mediatype
+      ? new MediaTypeField(this.rawMetadata.fields.mediatype)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get publicdate(): typeof Metadata.prototype.publicdate {
+    return this.rawMetadata?.fields?.publicdate
+      ? new DateField(this.rawMetadata.fields.publicdate)
+      : undefined;
+  }
+
+  /**
+   * Computed in processing of FTS API hit.
+   * Potentially irrelevant for TVS hit.
+   */
+  @Memoize() get result_in_subfile(): BooleanField | undefined {
+    return this.rawMetadata?.fields?.result_in_subfile != null
+      ? new BooleanField(this.rawMetadata.fields.result_in_subfile)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get reviewdate(): typeof Metadata.prototype.reviewdate {
+    return this.rawMetadata?.fields?.reviewdate
+      ? new DateField(this.rawMetadata.fields.reviewdate)
+      : undefined;
+  }
+
+  /**
+   * Format varies.
+   * Optional.
+   */
+  @Memoize() get source(): typeof Metadata.prototype.source {
+    return this.rawMetadata?.fields?.source
+      ? new StringField(this.rawMetadata.fields.source)
+      : undefined;
+  }
+
+  /**
+   * Optional.
+   * Multivalued.
+   */
+  @Memoize() get subject(): StringField | undefined {
+    return this.rawMetadata?.fields?.subject
+      ? new StringField(this.rawMetadata.fields.subject)
+      : undefined;
+  }
+
+  /** Optional. */
+  @Memoize() get title(): typeof Metadata.prototype.title {
+    return this.rawMetadata?.fields?.title
+      ? new StringField(this.rawMetadata.fields.title)
+      : undefined;
+  }
+
+  @Memoize() get updated_on(): DateField | undefined {
+    return this.rawMetadata?.fields?.updated_on
+      ? new DateField(this.rawMetadata.fields.updated_on)
+      : undefined;
+  }
+
+  /**
+   * Computed from date.
+   * Optional.
+   */
+  @Memoize() get year(): NumberField | undefined {
+    return this.rawMetadata?.fields?.year != null
+      ? new NumberField(this.rawMetadata.fields.year)
+      : undefined;
+  }
+
+  /**
+   * Optional.
+   * Start time for TV hit.
+   */
+  @Memoize() get start(): StringField | undefined {
+    return this.rawMetadata?.fields?.start != null
+      ? new StringField(this.rawMetadata.fields.start)
+      : undefined;
+  }
+
+  /**
+   * Synthesized in processing of TVS API hit; TBD
+   * Optional.
+   */
+  @Memoize() get __href__(): StringField | undefined {
+    return this.rawMetadata?.fields?.__href__
+      ? new StringField(this.rawMetadata.fields.__href__)
+      : undefined;
+  }
+}

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -18,7 +18,11 @@ export type PageElementName =
   | 'collections'
   | 'lending'
   | 'web_archives'
-  | 'forum_posts';
+  | 'forum_posts'
+  | 'full_text'
+  | 'tv_captions'
+  | 'radio_captions'
+  | 'media_transcription';
 
 /**
  * A basic page element returning hits and/or aggregations
@@ -74,6 +78,7 @@ export interface Review {
 export type UploadsPageElement = HitsAggregationsPageElement;
 export type ReviewsPageElement = HitsAggregationsPageElement;
 export type CollectionsPageElement = HitsAggregationsPageElement;
+export type FederatedPageElement = SearchResponseHits;
 
 export const LENDING_SUB_ELEMENTS = [
   'loans',
@@ -95,11 +100,13 @@ export type PageElement =
   | CollectionsPageElement
   | LendingPageElement
   | WebArchivesPageElement
-  | ForumPostsPageElement;
+  | ForumPostsPageElement
+  | FederatedPageElement;
 
 /**
  * A map containing one or more page elements returned by the PPS, keyed by the
  * name of the element.
+ * TODO: Add FederatedPageElement metadata once it has been added to the endpoint
  */
 export interface PageElementMap
   extends Partial<Record<PageElementName, PageElement>> {
@@ -109,6 +116,10 @@ export interface PageElementMap
   lending?: LendingPageElement;
   web_archives?: WebArchivesPageElement;
   forum_posts?: ForumPostsPageElement;
+  full_text?: FederatedPageElement;
+  tv_captions?: FederatedPageElement;
+  radio_captions?: FederatedPageElement;
+  media_transcription?: FederatedPageElement;
 }
 
 /**

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -10,10 +10,11 @@ export interface SearchResponseHits {
 }
 
 export type FederatedServiceName =
-  | 'full_text'
-  | 'tv_captions'
-  | 'radio_captions'
-  | 'media_transcription';
+  | 'item_metadata'
+  | 'fts'
+  | 'tvs'
+  | 'rcs'
+  | 'whisper';
 
 /**
  * Valid page element names recognized & returned by the PPS
@@ -109,7 +110,6 @@ export type PageElement =
 /**
  * A map containing one or more page elements returned by the PPS, keyed by the
  * name of the element.
- * TODO: Add FederatedPageElement metadata once it has been added to the endpoint
  */
 export interface PageElementMap
   extends Partial<Record<PageElementName, PageElement>> {
@@ -119,10 +119,11 @@ export interface PageElementMap
   lending?: LendingPageElement;
   web_archives?: WebArchivesPageElement;
   forum_posts?: ForumPostsPageElement;
-  full_text?: FederatedPageElement;
-  tv_captions?: FederatedPageElement;
-  radio_captions?: FederatedPageElement;
-  media_transcription?: FederatedPageElement;
+  item_metadata?: FederatedPageElement;
+  fts?: FederatedPageElement;
+  tvs?: FederatedPageElement;
+  rcs?: FederatedPageElement;
+  whisper?: FederatedPageElement;
 }
 
 /**

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -9,6 +9,12 @@ export interface SearchResponseHits {
   hits: Record<string, unknown>[];
 }
 
+export type FederatedServiceName =
+  | 'full_text'
+  | 'tv_captions'
+  | 'radio_captions'
+  | 'media_transcription';
+
 /**
  * Valid page element names recognized & returned by the PPS
  */
@@ -19,10 +25,7 @@ export type PageElementName =
   | 'lending'
   | 'web_archives'
   | 'forum_posts'
-  | 'full_text'
-  | 'tv_captions'
-  | 'radio_captions'
-  | 'media_transcription';
+  | FederatedServiceName;
 
 /**
  * A basic page element returning hits and/or aggregations
@@ -78,7 +81,7 @@ export interface Review {
 export type UploadsPageElement = HitsAggregationsPageElement;
 export type ReviewsPageElement = HitsAggregationsPageElement;
 export type CollectionsPageElement = HitsAggregationsPageElement;
-export type FederatedPageElement = SearchResponseHits;
+export type FederatedPageElement = HitsAggregationsPageElement;
 
 export const LENDING_SUB_ELEMENTS = [
   'loans',

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -10,11 +10,10 @@ export interface SearchResponseHits {
 }
 
 export type FederatedServiceName =
-  | 'item_metadata'
-  | 'fts'
-  | 'tvs'
-  | 'rcs'
-  | 'whisper';
+  | 'service___fts'
+  | 'service___tvs'
+  | 'service___rcs'
+  | 'service___whisper';
 
 /**
  * Valid page element names recognized & returned by the PPS
@@ -119,11 +118,10 @@ export interface PageElementMap
   lending?: LendingPageElement;
   web_archives?: WebArchivesPageElement;
   forum_posts?: ForumPostsPageElement;
-  item_metadata?: FederatedPageElement;
-  fts?: FederatedPageElement;
-  tvs?: FederatedPageElement;
-  rcs?: FederatedPageElement;
-  whisper?: FederatedPageElement;
+  service___fts?: FederatedPageElement;
+  service___tvs?: FederatedPageElement;
+  service___rcs?: FederatedPageElement;
+  service___whisper?: FederatedPageElement;
 }
 
 /**

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -5,6 +5,7 @@ import { ItemHit } from '../models/hit-types/item-hit';
 import { TextHit } from '../models/hit-types/text-hit';
 import { FavoritedSearchHit } from '../models/hit-types/favorited-search-hit';
 import { WebArchiveHit } from '../models/hit-types/web-archive-hit';
+import { TvClipHit } from '../models/hit-types/tv-clip-hit';
 import { CollectionExtraInfo } from './collection-extra-info';
 import type { SearchHitSchema } from './search-hit-schema';
 import { AccountExtraInfo } from './account-extra-info';
@@ -259,6 +260,7 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
     switch (type) {
       case 'item':
         return new ItemHit(result);
+      case 'asr_text':
       case 'text':
       case 'asr_text':
         return new TextHit(result);
@@ -266,6 +268,8 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
         return new FavoritedSearchHit(result);
       case 'web_archive':
         return new WebArchiveHit(result);
+      case 'tv_clip':
+        return new TvClipHit(result);
       default:
         // The hit type doesn't tell us what to construct, so just construct an ItemHit
         return new ItemHit(result);

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -183,7 +183,9 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
     this.totalResults = body?.hits?.total ?? 0;
     this.returnedCount = body?.hits?.returned ?? 0;
 
-    // Use total hits from search services if federated search
+    // If page elements include services i.e. fts,
+    // this indicates a federated search,
+    // so we should trigger the fed search results handler
     if (!hits?.length && this.pageElements?.service___fts) {
       this.totalResults = 0;
       this.returnedCount = 0;
@@ -310,10 +312,13 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
     for (const service of SEARCH_SERVICES) {
       const simpleServiceName: string = this.removeServicePrefix(service);
 
-      // Add service name to federated results section
-      this.federatedResults
-        ? (this.federatedResults[service] = [])
-        : (this.federatedResults = { [simpleServiceName]: [] });
+      // Add service name to federated results section.
+      // Create section if not already created.
+      if (this.federatedResults) {
+        this.federatedResults[service] = [];
+      } else {
+        this.federatedResults = { [simpleServiceName]: [] };
+      }
 
       // Add hits to service
       const serviceElementHits = this.pageElements?.[service]?.hits;

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -355,7 +355,6 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
     switch (type) {
       case 'item':
         return new ItemHit(result);
-      case 'asr_text':
       case 'text':
       case 'asr_text':
         return new TextHit(result);

--- a/src/search-backend/federated-search-backend.ts
+++ b/src/search-backend/federated-search-backend.ts
@@ -6,9 +6,6 @@ import { SearchParamURLGenerator } from '../search-param-url-generator';
 import { BaseSearchBackend } from './base-search-backend';
 import type { SearchBackendOptionsInterface } from './search-backend-options';
 
-/* Temporary URL for prototyping purposes */
-const PROTOTYPE_URL = 'ia-petabox-ximm-search-simple-federation.archive.org/';
-
 /**
  * The FederatedSearchBackend performs a `window.fetch` request to archive.org
  */
@@ -19,9 +16,6 @@ export class FederatedSearchBackend extends BaseSearchBackend {
     super(options);
     this.servicePath =
       options?.servicePath ?? '/services/search/beta/page_production';
-
-    // TODO: Remove this when we're no longer using the temp URL
-    this.baseUrl = PROTOTYPE_URL;
   }
 
   /** @inheritdoc */

--- a/src/search-backend/federated-search-backend.ts
+++ b/src/search-backend/federated-search-backend.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { SearchParams } from '../search-params';
+import type { Result } from '@internetarchive/result-type';
+import type { SearchServiceError } from '../search-service-error';
+import { SearchParamURLGenerator } from '../search-param-url-generator';
+import { BaseSearchBackend } from './base-search-backend';
+import type { SearchBackendOptionsInterface } from './search-backend-options';
+
+/* Temporary URL for prototyping purposes */
+const PROTOTYPE_URL = 'ia-petabox-ximm-search-simple-federation.archive.org/';
+
+/**
+ * The FederatedSearchBackend performs a `window.fetch` request to archive.org
+ */
+export class FederatedSearchBackend extends BaseSearchBackend {
+  private servicePath: string;
+
+  constructor(options?: SearchBackendOptionsInterface) {
+    super(options);
+    this.servicePath =
+      options?.servicePath ?? '/services/search/beta/page_production';
+      
+    // TODO: Remove this when we're no longer using the temp URL
+    this.baseUrl = PROTOTYPE_URL;
+  }
+
+  /** @inheritdoc */
+  async performSearch(
+    params: SearchParams
+  ): Promise<Result<any, SearchServiceError>> {
+    if (this.debuggingEnabled && params.debugging === undefined) {
+      params.debugging = true;
+    }
+
+    const urlSearchParam = SearchParamURLGenerator.generateURLSearchParams(
+      params
+    );
+    const queryAsString = urlSearchParam.toString();
+    const url = `https://${this.baseUrl}${this.servicePath}/?page_type=simple_federation&${queryAsString}`;
+    return this.fetchUrl(url);
+  }
+}

--- a/src/search-backend/federated-search-backend.ts
+++ b/src/search-backend/federated-search-backend.ts
@@ -19,7 +19,7 @@ export class FederatedSearchBackend extends BaseSearchBackend {
     super(options);
     this.servicePath =
       options?.servicePath ?? '/services/search/beta/page_production';
-      
+
     // TODO: Remove this when we're no longer using the temp URL
     this.baseUrl = PROTOTYPE_URL;
   }

--- a/src/search-service.ts
+++ b/src/search-service.ts
@@ -10,6 +10,7 @@ import { FulltextSearchBackend } from './search-backend/fulltext-search-backend'
 import { MetadataSearchBackend } from './search-backend/metadata-search-backend';
 import { Memoize } from 'typescript-memoize';
 import { RadioSearchBackend } from './search-backend/radio-search-backend';
+import { FederatedSearchBackend } from './search-backend/federated-search-backend';
 
 /**
  * The Search Service is responsible for taking the raw response provided by
@@ -68,6 +69,8 @@ export class SearchService implements SearchServiceInterface {
         return new FulltextSearchBackend(options);
       case SearchType.RADIO:
         return new RadioSearchBackend(options);
+      case SearchType.FEDERATED:
+        return new FederatedSearchBackend(options);
       case SearchType.METADATA:
       default:
         return new MetadataSearchBackend(options);

--- a/src/search-type.ts
+++ b/src/search-type.ts
@@ -8,4 +8,5 @@ export enum SearchType {
   //TV, // not yet available
   RADIO = 3, // explicit value for now, just to maintain consistency when we add TV later
   // and so that the order matches how we present these options beside search widgets
+  FEDERATED = 4, // temp explicit value to be removed when TV added
 }

--- a/test/models/hit-types/tv-clip-hit.test.ts
+++ b/test/models/hit-types/tv-clip-hit.test.ts
@@ -1,0 +1,142 @@
+import { DateParser } from '@internetarchive/field-parsers';
+import { expect } from '@open-wc/testing';
+import { TvClipHit } from '../../../src/models/hit-types/tv-clip-hit';
+import { DateField } from '../../../src/models/metadata-fields/field-types/date';
+
+const fieldNames: (keyof TvClipHit)[] = [
+  'identifier',
+  'addeddate',
+  'avg_rating',
+  'collection',
+  'created_on',
+  'creator',
+  'date',
+  'description',
+  'downloads',
+  'filename',
+  'file_basename',
+  'file_creation_mtime',
+  'highlight',
+  'issue',
+  'mediatype',
+  'publicdate',
+  'result_in_subfile',
+  'reviewdate',
+  'source',
+  'subject',
+  'title',
+  'updated_on',
+  'year',
+  'start',
+  '__href__',
+];
+
+describe('TvClipHit', () => {
+  it('constructs basic tv clip hit', () => {
+    const hit = new TvClipHit({ fields: {} });
+    expect(hit.rawMetadata).to.deep.equal({ fields: {} });
+    expect(hit.creator).to.be.undefined;
+  });
+
+  it('handles missing data gracefully', () => {
+    const hit = new TvClipHit({});
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
+  });
+
+  it('handles incomplete field data gracefully', () => {
+    const hit = new TvClipHit({ fields: {} });
+    for (const key of fieldNames) {
+      expect(hit[key]).to.be.undefined;
+    }
+  });
+
+  it('constructs a TV clip hit with all fields', () => {
+    const json = {
+      fields: {
+        identifier: 'foo',
+        mediatype: 'texts',
+        filename: 'foo-file.txt',
+        file_basename: 'foo-file',
+        file_creation_mtime: 1161893250,
+        updated_on: '2022-04-06T08:34:38Z',
+        created_on: '2016-10-09T16:51:05Z',
+        title: 'foo-title',
+        creator: ['foo-creator'],
+        subject: ['foo-subject1', 'foo-subject2'],
+        addeddate: '1904-01-01T00:00:00Z',
+        avg_rating: 3,
+        issue: 'foo-issue',
+        source: 'foo-source',
+        date: '1904-01-01T00:00:00Z',
+        reviewdate: '1904-01-01T00:00:00Z',
+        publicdate: '2006-10-11T08:19:20Z',
+        downloads: 1234,
+        collection: ['foo-collection'],
+        year: 2011,
+        result_in_subfile: false,
+        description: 'foo-description',
+        start: '52',
+        __href__: '/details/foo/start/52/end/112?q=bar',
+      },
+      highlight: {
+        text: ['foo {{{bar}}} baz'],
+      },
+      _score: 1,
+    };
+
+    const hit = new TvClipHit(json);
+    expect(hit.rawMetadata).to.deep.equal(json);
+    expect(hit.identifier).to.equal(json.fields.identifier);
+
+    // Ensure all existing fields are present
+    for (const key of Object.keys(json.fields)) {
+      if (key === 'identifier') continue;
+      const fieldName = key as Exclude<keyof typeof json.fields, 'identifier'>;
+
+      if (Array.isArray(json.fields[fieldName])) {
+        expect(hit[fieldName]?.values).to.deep.equal(
+          json.fields[fieldName],
+          fieldName
+        );
+      } else if (hit[fieldName] instanceof DateField) {
+        expect(hit[fieldName]?.value).to.deep.equal(
+          DateParser.shared.parseValue(json.fields[fieldName].toString()),
+          fieldName
+        );
+      } else {
+        expect(hit[fieldName]?.value).to.equal(
+          json.fields[fieldName],
+          fieldName
+        );
+      }
+    }
+
+    expect(hit.highlight?.values).to.deep.equal(json.highlight.text);
+  });
+
+  it('correctly parses falsey boolean/numeric fields', () => {
+    const json = {
+      fields: {
+        identifier: 'foo',
+        result_in_subfile: false,
+        file_creation_mtime: 0,
+        avg_rating: 0,
+        downloads: 0,
+        year: 0,
+      },
+      highlight: {
+        text: [],
+      },
+      _score: 0,
+    };
+
+    const hit = new TvClipHit(json);
+    expect(hit.result_in_subfile?.value).to.be.false;
+    expect(hit.file_creation_mtime?.value).to.equal(0);
+    expect(hit.avg_rating?.value).to.equal(0);
+    expect(hit.downloads?.value).to.equal(0);
+    expect(hit.year?.value).to.equal(0);
+  });
+});

--- a/test/responses/search-response-details.test.ts
+++ b/test/responses/search-response-details.test.ts
@@ -219,11 +219,25 @@ const accountWebArchivesResponseBody: SearchResponseBody = {
   },
 };
 
-// TODO: Add metada when it has been added to the endpoint
 // Also add a corresponding test to ensure metadata is used to populate response.results
 const federatedSearchResponseBody: SearchResponseBody = {
   page_elements: {
-    full_text: {
+    item_metadata: {
+      hits: {
+        total: 2,
+        returned: 1,
+        hits: [
+          {
+            hit_type: 'text',
+            fields: {
+              identifier: 'first_metadata',
+              mediatype: 'texts',
+            },
+          },
+        ],
+      },
+    },
+    fts: {
       hits: {
         total: 2,
         returned: 2,
@@ -245,7 +259,7 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    tv_captions: {
+    tvs: {
       hits: {
         total: 1,
         returned: 1,
@@ -262,7 +276,7 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    radio_captions: {
+    rcs: {
       hits: {
         total: 1,
         returned: 1,
@@ -277,7 +291,7 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    media_transcription: {
+    whisper: {
       hits: {
         total: 1,
         returned: 1,
@@ -555,11 +569,11 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    // TODO: Add metadata
-    expect(details.pageElements?.full_text?.hits?.hits).to.exist;
-    expect(details.pageElements?.tv_captions?.hits?.hits).to.exist;
-    expect(details.pageElements?.radio_captions?.hits?.hits).to.exist;
-    expect(details.pageElements?.media_transcription?.hits?.hits).to.exist;
+    expect(details.pageElements?.item_metadata?.hits?.hits).to.exist;
+    expect(details.pageElements?.fts?.hits?.hits).to.exist;
+    expect(details.pageElements?.tvs?.hits?.hits).to.exist;
+    expect(details.pageElements?.rcs?.hits?.hits).to.exist;
+    expect(details.pageElements?.whisper?.hits?.hits).to.exist;
   });
 
   it('provides access to the hit counts from each federated search service', () => {
@@ -568,11 +582,11 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    // TODO: Add metadata
-    expect(details.pageElements?.full_text?.hits?.total).to.equal(2);
-    expect(details.pageElements?.tv_captions?.hits?.total).to.equal(1);
-    expect(details.pageElements?.radio_captions?.hits?.total).to.equal(1);
-    expect(details.pageElements?.media_transcription?.hits?.total).to.equal(1);
+    expect(details.pageElements?.item_metadata?.hits?.total).to.equal(2);
+    expect(details.pageElements?.fts?.hits?.total).to.equal(2);
+    expect(details.pageElements?.tvs?.hits?.total).to.equal(1);
+    expect(details.pageElements?.rcs?.hits?.total).to.equal(1);
+    expect(details.pageElements?.whisper?.hits?.total).to.equal(1);
   });
 
   it('adds each service result count to total', () => {
@@ -581,7 +595,27 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.totalResults).to.equal(5);
+    expect(details.totalResults).to.equal(7);
+  });
+
+  it('adds each service returned count to total', () => {
+    const details = new SearchResponseDetails(
+      federatedSearchResponseBody,
+      {} as SearchHitSchema
+    );
+
+    expect(details.returnedCount).to.equal(6);
+  });
+
+  it('uses the metadata results to populate the main results', () => {
+    const details = new SearchResponseDetails(
+      federatedSearchResponseBody,
+      {} as SearchHitSchema
+    );
+
+    expect(details.results[0]).to.exist;
+    expect(details.results[0].identifier).to.equal('first_metadata');
+    expect(details.results[0]).to.be.instanceOf(TextHit);
   });
 
   it('constructs text hits from federated full-text search', () => {
@@ -590,7 +624,7 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.federatedResults?.full_text[0]).to.be.instanceOf(TextHit);
+    expect(details.federatedResults?.fts[0]).to.be.instanceOf(TextHit);
   });
 
   it('constructs TV clip hits from federated TV search', () => {
@@ -599,9 +633,7 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.federatedResults?.tv_captions[0]).to.be.instanceOf(
-      TvClipHit
-    );
+    expect(details.federatedResults?.tvs[0]).to.be.instanceOf(TvClipHit);
   });
 
   it('constructs text hits from federated radio search', () => {
@@ -610,9 +642,7 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.federatedResults?.radio_captions[0]).to.be.instanceOf(
-      TextHit
-    );
+    expect(details.federatedResults?.rcs[0]).to.be.instanceOf(TextHit);
   });
 
   it('constructs text hits from federated media transcription search', () => {
@@ -621,8 +651,6 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.federatedResults?.media_transcription[0]).to.be.instanceOf(
-      TextHit
-    );
+    expect(details.federatedResults?.whisper[0]).to.be.instanceOf(TextHit);
   });
 });

--- a/test/responses/search-response-details.test.ts
+++ b/test/responses/search-response-details.test.ts
@@ -222,22 +222,7 @@ const accountWebArchivesResponseBody: SearchResponseBody = {
 // Also add a corresponding test to ensure metadata is used to populate response.results
 const federatedSearchResponseBody: SearchResponseBody = {
   page_elements: {
-    item_metadata: {
-      hits: {
-        total: 2,
-        returned: 1,
-        hits: [
-          {
-            hit_type: 'text',
-            fields: {
-              identifier: 'first_metadata',
-              mediatype: 'texts',
-            },
-          },
-        ],
-      },
-    },
-    fts: {
+    service___fts: {
       hits: {
         total: 2,
         returned: 2,
@@ -259,7 +244,7 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    tvs: {
+    service___tvs: {
       hits: {
         total: 1,
         returned: 1,
@@ -276,7 +261,7 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    rcs: {
+    service___rcs: {
       hits: {
         total: 1,
         returned: 1,
@@ -291,9 +276,9 @@ const federatedSearchResponseBody: SearchResponseBody = {
         ],
       },
     },
-    whisper: {
+    service___whisper: {
       hits: {
-        total: 1,
+        total: 2,
         returned: 1,
         hits: [
           {
@@ -569,11 +554,10 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.pageElements?.item_metadata?.hits?.hits).to.exist;
-    expect(details.pageElements?.fts?.hits?.hits).to.exist;
-    expect(details.pageElements?.tvs?.hits?.hits).to.exist;
-    expect(details.pageElements?.rcs?.hits?.hits).to.exist;
-    expect(details.pageElements?.whisper?.hits?.hits).to.exist;
+    expect(details.pageElements?.service___fts?.hits?.hits).to.exist;
+    expect(details.pageElements?.service___tvs?.hits?.hits).to.exist;
+    expect(details.pageElements?.service___rcs?.hits?.hits).to.exist;
+    expect(details.pageElements?.service___whisper?.hits?.hits).to.exist;
   });
 
   it('provides access to the hit counts from each federated search service', () => {
@@ -582,11 +566,10 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.pageElements?.item_metadata?.hits?.total).to.equal(2);
-    expect(details.pageElements?.fts?.hits?.total).to.equal(2);
-    expect(details.pageElements?.tvs?.hits?.total).to.equal(1);
-    expect(details.pageElements?.rcs?.hits?.total).to.equal(1);
-    expect(details.pageElements?.whisper?.hits?.total).to.equal(1);
+    expect(details.pageElements?.service___fts?.hits?.total).to.equal(2);
+    expect(details.pageElements?.service___tvs?.hits?.total).to.equal(1);
+    expect(details.pageElements?.service___rcs?.hits?.total).to.equal(1);
+    expect(details.pageElements?.service___whisper?.hits?.total).to.equal(2);
   });
 
   it('adds each service result count to total', () => {
@@ -595,7 +578,7 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.totalResults).to.equal(7);
+    expect(details.totalResults).to.equal(6);
   });
 
   it('adds each service returned count to total', () => {
@@ -604,18 +587,7 @@ describe('SearchResponseDetails', () => {
       {} as SearchHitSchema
     );
 
-    expect(details.returnedCount).to.equal(6);
-  });
-
-  it('uses the metadata results to populate the main results', () => {
-    const details = new SearchResponseDetails(
-      federatedSearchResponseBody,
-      {} as SearchHitSchema
-    );
-
-    expect(details.results[0]).to.exist;
-    expect(details.results[0].identifier).to.equal('first_metadata');
-    expect(details.results[0]).to.be.instanceOf(TextHit);
+    expect(details.returnedCount).to.equal(5);
   });
 
   it('constructs text hits from federated full-text search', () => {

--- a/test/search-backend/federated-search-backend.test.ts
+++ b/test/search-backend/federated-search-backend.test.ts
@@ -53,9 +53,7 @@ describe('FederatedSearchBackend', () => {
       ).to.equal('simple_federation');
     });
 
-    // TODO: Uncomment this test when we're no longer using the prototype URL
-
-    /* it('uses the provided service path', async () => {
+    it('uses the provided service path', async () => {
       const backend = new FederatedSearchBackend({
         baseUrl: 'foo.bar',
         servicePath: '/baz',
@@ -65,7 +63,7 @@ describe('FederatedSearchBackend', () => {
       expect(urlCalled!.toString()).to.satisfy((url: string) =>
         url.startsWith('https://foo.bar/baz')
       );
-    }); */
+    });
 
     it('includes credentials for search endpoint if requested', async () => {
       const backend = new FederatedSearchBackend({

--- a/test/search-backend/federated-search-backend.test.ts
+++ b/test/search-backend/federated-search-backend.test.ts
@@ -1,0 +1,347 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { expect } from '@open-wc/testing';
+import Sinon from 'sinon';
+import { FederatedSearchBackend } from '../../src/search-backend/federated-search-backend';
+import {
+  SearchServiceError,
+  SearchServiceErrorType,
+} from '../../src/search-service-error';
+
+describe('FederatedSearchBackend', () => {
+  describe('basic fetch behavior', () => {
+    let fetchBackup: typeof window.fetch;
+    let urlCalled: RequestInfo | URL;
+    let urlConfig: RequestInit | undefined;
+
+    beforeEach(() => {
+      fetchBackup = window.fetch;
+      urlCalled = '';
+      urlConfig = undefined;
+
+      window.fetch = (
+        url: RequestInfo | URL,
+        config?: RequestInit
+      ): Promise<Response> => {
+        urlCalled = url;
+        urlConfig = config;
+        const response = new Response('{ "foo": "bar" }');
+        return new Promise(resolve => resolve(response));
+      };
+    });
+
+    afterEach(() => {
+      window.fetch = fetchBackup;
+    });
+
+    it('can perform a search', async () => {
+      const backend = new FederatedSearchBackend();
+      const params = { query: 'foo' };
+      const result = await backend.performSearch(params);
+
+      expect(result.success?.foo).to.equal('bar');
+    });
+
+    it('sets the simple federation page type', async () => {
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        new URL(urlCalled!.toString()).searchParams.get('page_type')
+      ).to.equal('simple_federation');
+    });
+
+    // TODO: Uncomment this test when we're no longer using the prototype URL
+
+    /* it('uses the provided service path', async () => {
+      const backend = new FederatedSearchBackend({
+        baseUrl: 'foo.bar',
+        servicePath: '/baz',
+      });
+      await backend.performSearch({ query: 'boop' });
+
+      expect(urlCalled!.toString()).to.satisfy((url: string) =>
+        url.startsWith('https://foo.bar/baz')
+      );
+    }); */
+
+    it('includes credentials for search endpoint if requested', async () => {
+      const backend = new FederatedSearchBackend({
+        scope: 'foo',
+        includeCredentials: true,
+      });
+      await backend.performSearch({ query: 'foo' });
+
+      expect(urlConfig?.credentials).to.equal('include');
+    });
+
+    it('includes scope param from URL if not provided', async () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('scope', 'boop');
+      window.history.replaceState({}, '', url.toString());
+
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('scope')).to.equal('boop');
+
+      url.searchParams.delete('scope');
+      window.history.replaceState({}, '', url.toString());
+    });
+
+    it('includes caching param if provided', async () => {
+      const cachingParam = JSON.stringify({ bypass: true });
+      const backend = new FederatedSearchBackend({
+        caching: cachingParam,
+      });
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal(cachingParam);
+    });
+
+    it('includes caching param from URL if not provided', async () => {
+      const cachingParam = JSON.stringify({ bypass: true });
+
+      const url = new URL(window.location.href);
+      url.searchParams.set('caching', cachingParam);
+      window.history.replaceState({}, '', url.toString());
+
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal(cachingParam);
+
+      url.searchParams.delete('caching');
+      window.history.replaceState({}, '', url.toString());
+    });
+
+    it('includes reCache param from URL if not provided', async () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('reCache', '1');
+      window.history.replaceState({}, '', url.toString());
+
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal('{"recompute":true}');
+
+      url.searchParams.delete('reCache');
+      window.history.replaceState({}, '', url.toString());
+    });
+
+    it('includes noCache param from URL if not provided', async () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('noCache', '1');
+      window.history.replaceState({}, '', url.toString());
+
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal('{"bypass":true}');
+
+      url.searchParams.delete('noCache');
+      window.history.replaceState({}, '', url.toString());
+    });
+
+    it('includes dontCache param from URL if not provided', async () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('dontCache', '1');
+      window.history.replaceState({}, '', url.toString());
+
+      const backend = new FederatedSearchBackend();
+      await backend.performSearch({ query: 'foo' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('caching')).to.equal('{"no_compute":true}');
+
+      url.searchParams.delete('dontCache');
+      window.history.replaceState({}, '', url.toString());
+    });
+
+    it('can enable debugging by default on all searches', async () => {
+      const backend = new FederatedSearchBackend({
+        baseUrl: 'foo.bar',
+        servicePath: '/baz',
+        debuggingEnabled: true,
+      });
+      await backend.performSearch({ query: 'boop' });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.equal('true');
+    });
+
+    it('can disable default debugging on individual searches', async () => {
+      const backend = new FederatedSearchBackend({
+        baseUrl: 'foo.bar',
+        servicePath: '/baz',
+        debuggingEnabled: true,
+      });
+      await backend.performSearch({
+        query: 'boop',
+        debugging: false,
+      });
+
+      const queryParams = new URL(urlCalled!.toString()).searchParams;
+      expect(queryParams.get('user_query')).to.equal('boop');
+      expect(queryParams.get('debugging')).to.be.null;
+    });
+  });
+
+  it('returns a network error result upon fetch errors', async () => {
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      throw new Error();
+    };
+
+    const backend = new FederatedSearchBackend();
+    const response = await backend.performSearch({ query: 'foo' });
+    expect(response).to.exist; // No error thrown
+    expect(response.error).to.be.instanceof(SearchServiceError);
+    expect(response.error?.type).to.equal(SearchServiceErrorType.networkError);
+
+    window.fetch = fetchBackup;
+  });
+
+  it('outputs debugging information if present', async () => {
+    const fetchBackup = window.fetch;
+    let urlCalled: RequestInfo | URL = '';
+    window.fetch = async (url: RequestInfo | URL) => {
+      urlCalled = url;
+      return new Response(
+        JSON.stringify({
+          debugging: {
+            messages: ['boop'],
+            data: {
+              bar: 'baz',
+            },
+          },
+        })
+      );
+    };
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new FederatedSearchBackend();
+    await backend.performSearch({ query: 'foo', debugging: true });
+    expect(urlCalled).to.include('debugging=true');
+    expect(logSpy.calledWithExactly('boop')).to.be.true;
+    expect(logSpy.calledWithExactly('bar', 'baz')).to.be.true;
+
+    window.fetch = fetchBackup;
+    console.log = logBackup;
+  });
+
+  it('handles incomplete debugging information gracefully', async () => {
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(
+        JSON.stringify({
+          debugging: {},
+        })
+      );
+    };
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new FederatedSearchBackend();
+    const response = await backend.performSearch({
+      query: 'foo',
+      debugging: true,
+    });
+    expect(response).to.exist; // No error thrown
+
+    window.fetch = fetchBackup;
+    console.log = logBackup;
+  });
+
+  it('logs response to console if verbose=true', async () => {
+    const responseObj = {
+      response: {
+        body: {
+          hits: {
+            hits: ['h1', 'h2', 'h3', 'h4', 'h5'],
+          },
+          aggregations: {
+            creator: {
+              buckets: ['c1', 'c2', 'c3', 'c4', 'c5'],
+            },
+          },
+        },
+      },
+    };
+
+    const expectedLogObj = {
+      response: {
+        body: {
+          hits: {
+            hits: ['h1', '*** 4 hits omitted ***'],
+          },
+          aggregations: {
+            creator: {
+              buckets: '*** 5 buckets omitted ***',
+            },
+          },
+        },
+      },
+    };
+
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(JSON.stringify(responseObj));
+    };
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new FederatedSearchBackend({ verbose: true });
+    await backend.performSearch({
+      query: 'boop',
+    });
+
+    expect(logSpy.callCount).to.be.greaterThan(0);
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
+    expect(logSpy.args[1][0]).to.equal(JSON.stringify(expectedLogObj, null, 2));
+
+    window.fetch = fetchBackup;
+    console.log = logBackup;
+  });
+
+  it('includes verbose param from URL if not provided', async () => {
+    const fetchBackup = window.fetch;
+    window.fetch = async () => {
+      return new Response(JSON.stringify({}));
+    };
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('verbose', '1');
+    window.history.replaceState({}, '', url.toString());
+
+    const logBackup = console.log;
+    const logSpy = Sinon.spy();
+    console.log = logSpy;
+
+    const backend = new FederatedSearchBackend();
+    await backend.performSearch({ query: 'foo' });
+
+    expect(logSpy.callCount).to.be.greaterThan(0);
+    expect(logSpy.args[0][0]).to.equal('***** RESPONSE RECEIVED *****');
+
+    window.fetch = fetchBackup;
+    console.log = logBackup;
+    url.searchParams.delete('verbose');
+    window.history.replaceState({}, '', url.toString());
+  });
+});

--- a/test/search-service.test.ts
+++ b/test/search-service.test.ts
@@ -16,6 +16,7 @@ import { SearchType } from '../src/search-type';
 import { MetadataSearchBackend } from '../src/search-backend/metadata-search-backend';
 import { FulltextSearchBackend } from '../src/search-backend/fulltext-search-backend';
 import { RadioSearchBackend } from '../src/search-backend/radio-search-backend';
+import { FederatedSearchBackend } from '../src/search-backend/federated-search-backend';
 
 describe('SearchService', () => {
   it('can search when requested', async () => {
@@ -159,5 +160,11 @@ describe('SearchService', () => {
     expect(
       SearchService.getBackendForSearchType(SearchType.RADIO)
     ).to.be.instanceOf(RadioSearchBackend);
+  });
+
+  it('factory method gets federated backend', async () => {
+    expect(
+      SearchService.getBackendForSearchType(SearchType.FEDERATED)
+    ).to.be.instanceOf(FederatedSearchBackend);
   });
 });


### PR DESCRIPTION
Adds a new search type (`SearchType.FEDERATED`) to the search service to fetch federated results from the new PPS endpoint. Intended to be used for search prototyping.

**Current endpoint service names in response:**
- Full text: `fts`
- TV: `tvs`
- Radio: `rcs`
- Whisper: `whisper`

**Accessing results:**
- `response.pageElements.fts.hits` --> a full raw `hits` object with totals, returned count, and an array of hits
- `response.federatedResults.fts` --> an array of hits correctly formatted as `TextHit`, `TVClipHit`, etc.
