### PR TITLE
WEBDEV-7310 Add is_archivist property to account info

### DIFF
--- a/src/responses/account-extra-info.ts
+++ b/src/responses/account-extra-info.ts
@@ -5,6 +5,8 @@
 export interface AccountExtraInfo {
   /** Details about the user account itself (screen name, identifier, creation date) */
   account_details: UserAccountDetails;
+  /** Whether the target account either has privs or is internal to archive.org */
+  is_archivist: boolean;
   /** User-editable metadata about the user account (title and description) */
   user_item_metadata: UserItemMetadata;
   /** Details about the preferences set by the user and the privileges they have */

--- a/test/responses/search-response-details.test.ts
+++ b/test/responses/search-response-details.test.ts
@@ -129,6 +129,7 @@ const accountUploadsResponseBody: SearchResponseBody = {
       user_item_identifier: '@foobar',
       user_since: '2010-01-02T03:04:05Z',
     },
+    is_archivist: false,
     policy_settings: {
       is_archive_user: true,
       preferences: [],
@@ -457,6 +458,7 @@ describe('SearchResponseDetails', () => {
     expect(details.accountExtraInfo?.user_item_metadata?.description).to.equal(
       'Foo bar baz'
     );
+    expect(details.accountExtraInfo?.is_archivist).to.be.false;
   });
 
   it('account extra info is optional', () => {


### PR DESCRIPTION
Mirrors a PPS change adding the `is_archivist` property to the `account_extra_info` branch.