### PR TITLE
WEBDEV-7090 Add partitioned mediatypes to federated search results

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,5 +48,6 @@ export {
   FieldFilter,
   FilterConstraint,
 } from './src/search-params';
+export { FederatedResults } from './src/responses/search-response-details';
 export { FilterMapBuilder } from './src/filter-map-builder';
 export { SearchServiceError } from './src/search-service-error';

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -15,6 +15,16 @@ export type FederatedServiceName =
   | 'service___rcs'
   | 'service___whisper';
 
+export type FederatedMediatypeName =
+  | 'metadata___mediatype___texts'
+  | 'metadata___mediatype___movies'
+  | 'metadata___mediatype___audio'
+  | 'metadata___mediatype___software'
+  | 'metadata___mediatype___image'
+  | 'metadata___mediatype___etree';
+
+export type FederatedPageElementName = FederatedServiceName | FederatedMediatypeName;
+
 /**
  * Valid page element names recognized & returned by the PPS
  */
@@ -25,7 +35,7 @@ export type PageElementName =
   | 'lending'
   | 'web_archives'
   | 'forum_posts'
-  | FederatedServiceName;
+  | FederatedPageElementName;
 
 /**
  * A basic page element returning hits and/or aggregations
@@ -122,6 +132,12 @@ export interface PageElementMap
   service___tvs?: FederatedPageElement;
   service___rcs?: FederatedPageElement;
   service___whisper?: FederatedPageElement;
+  metadata___mediatype___texts?: FederatedPageElement;
+  metadata___mediatype___movies?: FederatedPageElement;
+  metadata___mediatype___audio?: FederatedPageElement;
+  metadata___mediatype___software?: FederatedPageElement;
+  metadata___mediatype___image?: FederatedPageElement;
+  metadata___mediatype___etree?: FederatedPageElement;
 }
 
 /**

--- a/src/responses/page-elements.ts
+++ b/src/responses/page-elements.ts
@@ -23,7 +23,9 @@ export type FederatedMediatypeName =
   | 'metadata___mediatype___image'
   | 'metadata___mediatype___etree';
 
-export type FederatedPageElementName = FederatedServiceName | FederatedMediatypeName;
+export type FederatedPageElementName =
+  | FederatedServiceName
+  | FederatedMediatypeName;
 
 /**
  * Valid page element names recognized & returned by the PPS

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -17,6 +17,7 @@ import {
   LENDING_SUB_ELEMENTS,
   WebArchivesPageElement,
   FederatedServiceName,
+  FederatedPageElementName,
 } from './page-elements';
 
 /**
@@ -302,47 +303,53 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
    * Formats all non-metadata hits to a new federatedResults object in the results.
    */
   private handleFederatedPageElements(): void {
-    const SEARCH_SERVICES: FederatedServiceName[] = [
+    const FEDERATED_PAGE_ELEMENTS: FederatedPageElementName[] = [
       'service___fts',
       'service___tvs',
       'service___rcs',
       'service___whisper',
+      'metadata___mediatype___texts',
+      'metadata___mediatype___movies',
+      'metadata___mediatype___audio',
+      'metadata___mediatype___software',
+      'metadata___mediatype___image',
+      'metadata___mediatype___etree',
     ];
 
-    for (const service of SEARCH_SERVICES) {
-      const simpleServiceName: string = this.removeServicePrefix(service);
+    for (const element of FEDERATED_PAGE_ELEMENTS) {
+      const simpleElementName: string = this.removePageElementPrefix(element);
 
       // Add service name to federated results section.
       // Create section if not already created.
       if (this.federatedResults) {
-        this.federatedResults[service] = [];
+        this.federatedResults[element] = [];
       } else {
-        this.federatedResults = { [simpleServiceName]: [] };
+        this.federatedResults = { [simpleElementName]: [] };
       }
 
       // Add hits to service
-      const serviceElementHits = this.pageElements?.[service]?.hits;
-      if (serviceElementHits?.hits) {
-        this.federatedResults[simpleServiceName] = this.formatHits(
-          serviceElementHits?.hits
+      const pageElementHits = this.pageElements?.[element]?.hits;
+      if (pageElementHits?.hits) {
+        this.federatedResults[simpleElementName] = this.formatHits(
+          pageElementHits?.hits
         );
       }
 
       // Update totals with counts from this service
-      this.totalResults += serviceElementHits?.total ?? 0;
-      this.returnedCount += serviceElementHits?.returned ?? 0;
+      this.totalResults += pageElementHits?.total ?? 0;
+      this.returnedCount += pageElementHits?.returned ?? 0;
     }
   }
 
   /**
-   * Utility method to remove 'service___' from the beginning of federated service names,
-   * so that output will be cleaner.
+   * Utility method to remove 'service___' or 'metadata___mediatype___' from the beginning of
+   * federated page element names, so that output will be cleaner.
    *
-   * @param {FederatedServiceName} service Original service name
-   * @returns {string} Service name with prefix removed
+   * @param name Original page element name
+   * @returns Page element name with prefix removed
    */
-  private removeServicePrefix(service: FederatedServiceName): string {
-    return service.split('___')[1];
+  private removePageElementPrefix(name: FederatedPageElementName): string {
+    return name.split('___').pop() as string;
   }
 
   /**

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -16,7 +16,6 @@ import {
   convertWebArchivesToSearchHits,
   LENDING_SUB_ELEMENTS,
   WebArchivesPageElement,
-  FederatedServiceName,
   FederatedPageElementName,
 } from './page-elements';
 


### PR DESCRIPTION
Adjusts the federated search responses to include the partitioned mediatype results in addition to the cross-service results.