### PR TITLE
v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/iaux-item-metadata": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Version adds full support for the hits fields required by TV collections, as well as the `DEFAULT` search type to omit any explicit `service_backend` arg.