### PR TITLE
Upgrade item-metadata and field-parsers dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@internetarchive/iaux-item-metadata": "^1.0.5",
         "@internetarchive/result-type": "^0.0.1",
-        "decorator-cache-getter": "^1.0.0",
         "typescript-memoize": "^1.1.1"
       },
       "devDependencies": {
@@ -4177,11 +4176,6 @@
         "node": ">=6.4",
         "npm": ">=2.15"
       }
-    },
-    "node_modules/decorator-cache-getter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/decorator-cache-getter/-/decorator-cache-getter-1.0.0.tgz",
-      "integrity": "sha512-yB49c5qi0govRjpe18vutEkkKzosIt2XggYSs1Qyev1TJYTh2WmLgDp0dV6VJ/6yNBRlKG+qMG80Vy4Bg0mLJw=="
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -14657,11 +14651,6 @@
       "requires": {
         "esprima": "4.0.1"
       }
-    },
-    "decorator-cache-getter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/decorator-cache-getter/-/decorator-cache-getter-1.0.0.tgz",
-      "integrity": "sha512-yB49c5qi0govRjpe18vutEkkKzosIt2XggYSs1Qyev1TJYTh2WmLgDp0dV6VJ/6yNBRlKG+qMG80Vy4Bg0mLJw=="
     },
     "dedent": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "dependencies": {
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/result-type": "^0.0.1",
-    "decorator-cache-getter": "^1.0.0",
     "typescript-memoize": "^1.1.1"
   }
 }


### PR DESCRIPTION
Recent upgrades to the `@internetarchive/field-parsers` package addressed a bug with parsing UTC dates. A previous PR upgraded to the latest version of this package, but did not correspondingly upgrade the `iaux-item-metadata` package (which itself relies on the field parsers). This resulted in two different versions of the field parsers being used, seemingly breaking certain date-related tests when run locally.

This PR upgrades `iaux-item-metadata` so that it uses the same, latest version of the field parsers. Also removes an old unused dependency for cache decorators which we don't need anymore (superseded by `typescript-memoize`).