### PR TITLE
Bump version to v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/search-service",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/iaux-item-metadata": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/search-service",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A search service for the Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Version includes `item_count` field on TV hits and dependency upgrades.