### PR TITLE
WEBDEV-5427 Add support for `date_histogram` aggregations and TV channel aliases

### DIFF
--- a/src/models/aggregation.ts
+++ b/src/models/aggregation.ts
@@ -27,13 +27,21 @@ export enum AggregationSortType {
 }
 
 export interface AggregationOptions {
+  // All aggregations have buckets
   buckets: Bucket[] | number[];
   doc_count_error_upper_bound?: number;
   sum_other_doc_count?: number;
+  // Additional keys provided by the year_histogram aggregation
   first_bucket_key?: number;
   last_bucket_key?: number;
   number_buckets?: number;
   interval?: number;
+  // Additional keys provided by the monthly date_histogram aggregation
+  first_bucket_year?: number;
+  first_bucket_month?: number;
+  last_bucket_year?: number;
+  last_bucket_month?: number;
+  interval_in_months?: number;
 }
 
 /**
@@ -45,6 +53,7 @@ export class Aggregation {
    * other facets return a `Bucket` array.
    */
   readonly buckets: Bucket[] | number[];
+
   readonly doc_count_error_upper_bound?: number;
   readonly sum_other_doc_count?: number;
   readonly first_bucket_key?: number;
@@ -52,14 +61,27 @@ export class Aggregation {
   readonly number_buckets?: number;
   readonly interval?: number;
 
+  readonly first_bucket_year?: number;
+  readonly first_bucket_month?: number;
+  readonly last_bucket_year?: number;
+  readonly last_bucket_month?: number;
+  readonly interval_in_months?: number;
+
   constructor(options: AggregationOptions) {
     this.buckets = options.buckets;
+
     this.doc_count_error_upper_bound = options.doc_count_error_upper_bound;
     this.sum_other_doc_count = options.sum_other_doc_count;
     this.first_bucket_key = options.first_bucket_key;
     this.last_bucket_key = options.last_bucket_key;
     this.number_buckets = options.number_buckets;
     this.interval = options.interval;
+
+    this.first_bucket_year = options.first_bucket_year;
+    this.first_bucket_month = options.first_bucket_month;
+    this.last_bucket_year = options.last_bucket_year;
+    this.last_bucket_month = options.last_bucket_month;
+    this.interval_in_months = options.interval_in_months;
   }
 
   /**
@@ -116,6 +138,6 @@ export class Aggregation {
   private isRawNumberBuckets(
     buckets: Bucket[] | number[]
   ): buckets is number[] {
-    return typeof this.buckets[0] === 'number';
+    return typeof buckets[0] === 'number';
   }
 }

--- a/src/models/aggregation.ts
+++ b/src/models/aggregation.ts
@@ -29,8 +29,6 @@ export enum AggregationSortType {
 export interface AggregationOptions {
   // All aggregations have buckets
   buckets: Bucket[] | number[];
-  doc_count_error_upper_bound?: number;
-  sum_other_doc_count?: number;
   // Additional keys provided by the year_histogram aggregation
   first_bucket_key?: number;
   last_bucket_key?: number;
@@ -54,8 +52,6 @@ export class Aggregation {
    */
   readonly buckets: Bucket[] | number[];
 
-  readonly doc_count_error_upper_bound?: number;
-  readonly sum_other_doc_count?: number;
   readonly first_bucket_key?: number;
   readonly last_bucket_key?: number;
   readonly number_buckets?: number;
@@ -70,8 +66,6 @@ export class Aggregation {
   constructor(options: AggregationOptions) {
     this.buckets = options.buckets;
 
-    this.doc_count_error_upper_bound = options.doc_count_error_upper_bound;
-    this.sum_other_doc_count = options.sum_other_doc_count;
     this.first_bucket_key = options.first_bucket_key;
     this.last_bucket_key = options.last_bucket_key;
     this.number_buckets = options.number_buckets;

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -81,6 +81,11 @@ export interface SearchResponseDetailsInterface {
   collectionTitles?: Record<string, string>;
 
   /**
+   * A map from TV channel names (creators) to their network names.
+   */
+  tvChannelAliases?: Record<string, string>;
+
+  /**
    * Extra info about the target collection, returned when the page type is
    * `collection_details`.
    */
@@ -142,6 +147,11 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
    * @inheritdoc
    */
   collectionTitles?: Record<string, string>;
+
+  /**
+   * @inheritdoc
+   */
+  tvChannelAliases?: Record<string, string>;
 
   /**
    * @inheritdoc
@@ -222,6 +232,10 @@ export class SearchResponseDetails implements SearchResponseDetailsInterface {
 
     if (body?.collection_titles) {
       this.collectionTitles = body.collection_titles ?? {};
+    }
+
+    if (body?.tv_channel_aliases) {
+      this.tvChannelAliases = body.tv_channel_aliases ?? {};
     }
 
     if (body?.collection_extra_info) {

--- a/src/responses/search-response-details.ts
+++ b/src/responses/search-response-details.ts
@@ -26,6 +26,7 @@ export interface SearchResponseBody {
   hits?: SearchResponseHits;
   aggregations?: Record<string, Aggregation>;
   collection_titles?: Record<string, string>;
+  tv_channel_aliases?: Record<string, string>;
   collection_extra_info?: CollectionExtraInfo;
   account_extra_info?: AccountExtraInfo;
   page_elements?: PageElementMap;

--- a/test/models/aggregation.test.ts
+++ b/test/models/aggregation.test.ts
@@ -6,10 +6,8 @@ import {
 } from '../../src/models/aggregation';
 
 describe('Aggregation model', () => {
-  it('constructs with options', () => {
+  it('constructs with number buckets by year', () => {
     const buckets = [1, 2, 3, 4];
-    const doc_count_error_upper_bound = 10;
-    const sum_other_doc_count = 20;
     const first_bucket_key = 0;
     const last_bucket_key = 3;
     const number_buckets = 4;
@@ -17,8 +15,6 @@ describe('Aggregation model', () => {
 
     const agg = new Aggregation({
       buckets,
-      doc_count_error_upper_bound,
-      sum_other_doc_count,
       first_bucket_key,
       last_bucket_key,
       number_buckets,
@@ -26,14 +22,38 @@ describe('Aggregation model', () => {
     });
 
     expect(agg.buckets).to.equal(buckets);
-    expect(agg.doc_count_error_upper_bound).to.equal(
-      doc_count_error_upper_bound
-    );
-    expect(agg.sum_other_doc_count).to.equal(sum_other_doc_count);
     expect(agg.first_bucket_key).to.equal(first_bucket_key);
     expect(agg.last_bucket_key).to.equal(last_bucket_key);
     expect(agg.number_buckets).to.equal(number_buckets);
     expect(agg.interval).to.equal(interval);
+  });
+
+  it('constructs with number buckets by month', () => {
+    const buckets = [1, 2, 3, 4, 5];
+    const first_bucket_year = 2000;
+    const last_bucket_year = 2001;
+    const first_bucket_month = 3;
+    const last_bucket_month = 6;
+    const number_buckets = 5;
+    const interval_in_months = 3;
+
+    const agg = new Aggregation({
+      buckets,
+      first_bucket_year,
+      last_bucket_year,
+      first_bucket_month,
+      last_bucket_month,
+      number_buckets,
+      interval_in_months,
+    });
+
+    expect(agg.buckets).to.equal(buckets);
+    expect(agg.first_bucket_year).to.equal(first_bucket_year);
+    expect(agg.last_bucket_year).to.equal(last_bucket_year);
+    expect(agg.first_bucket_month).to.equal(first_bucket_month);
+    expect(agg.last_bucket_month).to.equal(last_bucket_month);
+    expect(agg.number_buckets).to.equal(number_buckets);
+    expect(agg.interval_in_months).to.equal(interval_in_months);
   });
 
   it('expects default sorted buckets by count', async () => {

--- a/test/responses/search-response-details.test.ts
+++ b/test/responses/search-response-details.test.ts
@@ -48,6 +48,9 @@ const responseBody: SearchResponseBody = {
   collection_titles: {
     baz: 'Baz Collection',
   },
+  tv_channel_aliases: {
+    foo: 'Foo Network',
+  },
   collection_extra_info: {
     thumbnail_url: 'foo',
   },
@@ -428,6 +431,26 @@ describe('SearchResponseDetails', () => {
     );
     expect(details.results.length).to.equal(2);
     expect(details.collectionTitles).to.be.undefined;
+  });
+
+  it('provides access to channel alias map', () => {
+    const details = new SearchResponseDetails(responseBody, itemSchema);
+    expect(details.results.length).to.equal(2);
+    expect(details.tvChannelAliases).to.deep.equal({ foo: 'Foo Network' });
+  });
+
+  it('channel alias map is optional', () => {
+    const responseBodyWithoutAliases = {
+      ...responseBody,
+    } as SearchResponseBody;
+    delete responseBodyWithoutAliases.tv_channel_aliases;
+
+    const details = new SearchResponseDetails(
+      responseBodyWithoutAliases,
+      itemSchema
+    );
+    expect(details.results.length).to.equal(2);
+    expect(details.tvChannelAliases).to.be.undefined;
   });
 
   it('provides access to collection extra info', () => {


### PR DESCRIPTION
- Updates aggregation model to support new keys used by the `date_histogram` aggregation (which has month resolution, unlike `year_histogram`)
- Removes some old, unused keys from aggregation models
- Adds support for the `tv_channel_aliases` response branch containing channel-to-network name mappings