### PR TITLE
WEBDEV-7667 Add missing fields to session context model

### DIFF
--- a/src/responses/search-response-session-context.ts
+++ b/src/responses/search-response-session-context.ts
@@ -10,8 +10,13 @@ export interface SearchResponseSessionContext {
   has_allowed_host_priv?: boolean;
   has_scan_center_priv?: boolean;
   has_any_priv?: boolean;
+  has_any_priv_permissive?: boolean;
+  has_collection_priv?: boolean;
   pps?: {
     is_page_target_owner?: boolean;
     full_text_search_override?: boolean;
+  };
+  pps_relevant_user_preferences?: {
+    display__blur_moderated_content?: string;
   };
 }


### PR DESCRIPTION
Adds the `has_any_priv_permissive`, `has_collection_priv`, and `pps_relevant_user_preferences` fields to the model for the session context branch of the PPS response.